### PR TITLE
Ensure trades meet profit/fee thresholds before exit

### DIFF
--- a/config.py
+++ b/config.py
@@ -75,7 +75,7 @@ FEE_PCT = float(os.getenv("FEE_PCT", "0.001"))
 
 # Minimum acceptable ratio of expected profit to total fees for a trade.
 # Trades falling below this profit-to-fee threshold will be skipped.
-MIN_PROFIT_FEE_RATIO = float(os.getenv("MIN_PROFIT_FEE_RATIO", "1.5"))
+MIN_PROFIT_FEE_RATIO = float(os.getenv("MIN_PROFIT_FEE_RATIO", "2.0"))
 
 # Number of bars to delay trade execution in backtests to model latency.
 EXECUTION_DELAY_BARS = int(os.getenv("EXECUTION_DELAY_BARS", "0"))

--- a/tests/test_trade_manager.py
+++ b/tests/test_trade_manager.py
@@ -170,3 +170,30 @@ def test_trailing_stop_respects_profit_threshold(monkeypatch):
     assert tm.positions['ABC'].get('trail_triggered') is True
     assert 'trail_price' in tm.positions['ABC']
 
+
+
+def test_close_trade_skips_when_profit_ratio_low(monkeypatch):
+    tm = TradeManager(starting_balance=1000, trade_fee_pct=0.01, min_profit_fee_ratio=2.0, hold_period_sec=0)
+    tm.positions['ABC'] = {
+        'coin_id': 'abc',
+        'entry_price': 100.0,
+        'qty': 1.0,
+        'stop_loss': 90.0,
+        'take_profit': 110.0,
+        'entry_fee': 1.0,
+        'highest_price': 100.0,
+        'confidence': 1.0,
+        'label': None,
+        'side': 'BUY',
+        'entry_time': 0.0,
+        'last_movement_time': 0.0,
+        'atr': None,
+    }
+    monkeypatch.setattr('data_fetcher.fetch_ohlcv_smart', lambda *a, **k: mock_indicator_df())
+    monkeypatch.setattr('feature_engineer.add_indicators', lambda d: d)
+
+    tm.close_trade('ABC', 100.5, reason='Take-Profit')
+    assert tm.has_position('ABC')
+
+    tm.close_trade('ABC', 105.0, reason='Take-Profit')
+    assert not tm.has_position('ABC')

--- a/trade_manager.py
+++ b/trade_manager.py
@@ -273,7 +273,7 @@ class TradeManager:
 
         if total_est_fees > 0 and expected_profit / total_est_fees < self.min_profit_fee_ratio:
             logger.info(
-                "💰 Skipping %s: expected profit $%.2f vs fees $%.2f (ratio %.2f < %.2f)",
+                "💰 Trade rejected for %s: expected profit $%.2f vs fees $%.2f (ratio %.2f < %.2f)",
                 symbol,
                 expected_profit,
                 total_est_fees,
@@ -394,6 +394,33 @@ class TradeManager:
         if elapsed < self.min_hold_time and reason in sl_tp_reasons:
             logger.info(
                 f"⏱️ Minimum hold time not met for {symbol} ({elapsed:.0f}s < {self.min_hold_time}s). Skipping close."
+            )
+            return
+
+        # Verify profitability before closing
+        qty = pos.get("qty", 0)
+        entry_price = pos["entry_price"]
+        side = pos.get("side", "BUY")
+        entry_fee = pos.get("entry_fee", 0)
+        exit_fee_est = current_price * qty * self.trade_fee_pct
+        if side == "BUY":
+            expected_profit = (current_price - entry_price) * qty
+        else:
+            expected_profit = (entry_price - current_price) * qty
+        total_fees = entry_fee + exit_fee_est
+        if (
+            expected_profit > 0
+            and total_fees > 0
+            and expected_profit / total_fees < self.min_profit_fee_ratio
+            and reason != "Stop-Loss"
+        ):
+            logger.info(
+                "💰 Exit for %s rejected: expected profit $%.2f vs fees $%.2f (ratio %.2f < %.2f)",
+                symbol,
+                expected_profit,
+                total_fees,
+                expected_profit / total_fees,
+                self.min_profit_fee_ratio,
             )
             return
 


### PR DESCRIPTION
## Summary
- Verify `min_profit_fee_ratio` during trade closing and skip exits when profit won't cover fees
- Raise default profit-to-fee ratio target to 2.0 to aim for higher net gains
- Log rejected trades for low profit-to-fee ratios and test new behavior

## Testing
- `/tmp/venv/bin/pytest`

------
https://chatgpt.com/codex/tasks/task_e_689db05b6c04832ca18dcd8c77935128