### PR TITLE
Increase minimum symbol performance thresholds

### DIFF
--- a/config.py
+++ b/config.py
@@ -89,14 +89,14 @@ EXECUTION_PRICE_WEIGHT = float(os.getenv("EXECUTION_PRICE_WEIGHT", "1.0"))
 CONFIDENCE_THRESHOLD = float(os.getenv("CONFIDENCE_THRESHOLD", "0.75"))
 
 # Minimum historical win rate (%) required for symbols to be considered.
-# Default to 50% so underperforming assets are filtered out unless
+# Default to 60% so underperforming assets are filtered out unless
 # explicitly overridden via the ``MIN_SYMBOL_WIN_RATE`` environment variable.
-MIN_SYMBOL_WIN_RATE = float(os.getenv("MIN_SYMBOL_WIN_RATE", "50"))
+MIN_SYMBOL_WIN_RATE = float(os.getenv("MIN_SYMBOL_WIN_RATE", "60"))
 
 # Minimum average PnL required for symbols to be considered.
-# Any symbol with non-positive average returns will be skipped unless this
-# threshold is lowered through ``MIN_SYMBOL_AVG_PNL``.
-MIN_SYMBOL_AVG_PNL = float(os.getenv("MIN_SYMBOL_AVG_PNL", "0.01"))
+# Any symbol with average returns at or below this threshold will be skipped
+# unless ``MIN_SYMBOL_AVG_PNL`` is overridden via environment variables.
+MIN_SYMBOL_AVG_PNL = float(os.getenv("MIN_SYMBOL_AVG_PNL", "0.05"))
 
 # Minimum bars to wait after a trade before opening a new one in backtests.
 HOLDING_PERIOD_BARS = int(os.getenv("HOLDING_PERIOD_BARS", "0"))

--- a/tests/test_scan_for_breakouts.py
+++ b/tests/test_scan_for_breakouts.py
@@ -92,7 +92,8 @@ def test_scan_for_breakouts_skips_low_performance(monkeypatch):
 
     # Configure performance data to fail thresholds
     main.SYMBOL_PERFORMANCE = {"BAD": {"avg_pnl": -0.1, "win_rate": 10}}
-    main.MIN_SYMBOL_WIN_RATE = 50
+    main.MIN_SYMBOL_WIN_RATE = 60
+    main.MIN_SYMBOL_AVG_PNL = 0.05
 
     monkeypatch.setattr(main, "get_top_gainers", lambda limit=15: [("id1", "BAD", "Bad", 10.0)])
 

--- a/tests/test_symbol_resolver.py
+++ b/tests/test_symbol_resolver.py
@@ -1,0 +1,23 @@
+import pytest
+
+from config import MIN_SYMBOL_AVG_PNL, MIN_SYMBOL_WIN_RATE
+from symbol_resolver import filter_candidates
+
+
+def test_filter_candidates_enforces_thresholds():
+    movers = [
+        ("id1", "AAA", "AAA Coin", 10.0),
+        ("id2", "BBB", "BBB Coin", 5.0),
+        ("id3", "CCC", "CCC Coin", 3.0),
+    ]
+    performance = {
+        # Meets both thresholds
+        "AAA": {"avg_pnl": MIN_SYMBOL_AVG_PNL + 0.01, "win_rate": MIN_SYMBOL_WIN_RATE + 5},
+        # Fails avg_pnl threshold
+        "BBB": {"avg_pnl": MIN_SYMBOL_AVG_PNL - 0.01, "win_rate": MIN_SYMBOL_WIN_RATE + 5},
+        # Fails win_rate threshold
+        "CCC": {"avg_pnl": MIN_SYMBOL_AVG_PNL + 0.01, "win_rate": MIN_SYMBOL_WIN_RATE - 5},
+    }
+
+    result = filter_candidates(movers, set(), performance)
+    assert result == [("id1", "AAA", "AAA Coin")]


### PR DESCRIPTION
## Summary
- raise default MIN_SYMBOL_WIN_RATE to 60%
- raise default MIN_SYMBOL_AVG_PNL to 0.05
- add tests to ensure filter_candidates rejects symbols not meeting performance thresholds
- update existing breakout scan test to reflect new limits

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689e6d21512c832c8094a51ea504f817