### PR TITLE
feat: adjust stop loss after fees covered

### DIFF
--- a/trade_manager.py
+++ b/trade_manager.py
@@ -598,6 +598,15 @@ class TradeManager:
                             unrealized = 0
                             total_fees = pos.get("entry_fee", 0)
 
+                        if side == "BUY" and unrealized >= total_fees:
+                            current_sl = pos.get("stop_loss", 0)
+                            if current_sl < entry_price:
+                                pos["stop_loss"] = entry_price
+                                logger.info(
+                                    f"🛡️ Fees covered for {symbol}; moved stop loss to entry {self.fmt_price(entry_price)}"
+                                )
+                                self.save_state()
+
                         threshold = self.trail_profit_fee_ratio * total_fees
                         if total_fees > 0 and unrealized < threshold:
                             logger.debug(


### PR DESCRIPTION
## Summary
- move stop-loss to entry price once unrealized PnL covers fees for BUY trades
- persist updated stop-loss to state

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689e6f21e174832ca2958a4b862f1e88