### PR TITLE
Increase ATR-based stop-loss buffer

### DIFF
--- a/config.py
+++ b/config.py
@@ -55,7 +55,7 @@ ERROR_DELAY = float(os.getenv("ERROR_DELAY", "0"))
 
 # Multipliers for ATR-based stop-loss and take-profit calculations.
 # These can be overridden via environment variables ATR_MULT_SL and ATR_MULT_TP.
-ATR_MULT_SL = float(os.getenv("ATR_MULT_SL", "1.5"))
+ATR_MULT_SL = float(os.getenv("ATR_MULT_SL", "2.0"))
 ATR_MULT_TP = float(os.getenv("ATR_MULT_TP", "3.0"))
 
 # === Risk management and trade sizing ===

--- a/tests/test_trade_manager.py
+++ b/tests/test_trade_manager.py
@@ -3,6 +3,7 @@ import pytest
 import numpy as np
 
 from trade_manager import TradeManager
+from config import ATR_MULT_SL
 
 
 def create_tm():
@@ -39,8 +40,9 @@ def test_open_trade_uses_atr_for_stops(monkeypatch):
     price = 10.0
     tm.open_trade('ABC', price, confidence=1.0)
     pos = tm.positions['ABC']
+    assert tm.atr_mult_sl == ATR_MULT_SL
     assert pos['atr'] == pytest.approx(1.0)
-    assert pos['stop_loss'] == pytest.approx(price - tm.atr_mult_sl * 1.0)
+    assert pos['stop_loss'] == pytest.approx(price - ATR_MULT_SL * 1.0)
     assert pos['take_profit'] == pytest.approx(price + tm.atr_mult_tp * 1.0)
 
 


### PR DESCRIPTION
## Summary
- widen default ATR-based stop-loss multiplier from 1.5 to 2.0 to reduce premature exits
- ensure TradeManager uses configured ATR multiplier when calculating stop loss
- cover multiplier via unit test

## Testing
- `pytest -q`
- `python - <<'PY'
from trade_manager import TradeManager

# Setup TradeManager with minimal extras


tm = TradeManager(starting_balance=1000, hold_period_sec=0)
print('ATR multiplier sl:', tm.atr_mult_sl)

tm.risk_per_trade = 1.0
tm.min_trade_usd = 0
tm.slippage_pct = 0.0
tm.trade_fee_pct = 0.0

# open trade with ATR = 1.0 at price 10

tm.open_trade('AAA', 10.0, confidence=1.0, atr=1.0)
stop_loss = tm.positions['AAA']['stop_loss']
print('Stop-loss set at', stop_loss)

# Price falls but stays above stop-loss

tm.manage('AAA', 8.6)
print('Still have position after 8.6?', tm.has_position('AAA'))
PY`

------
https://chatgpt.com/codex/tasks/task_e_689e702dcf50832ca98b941d9d302473