### PR TITLE
Persist fee rate in trade manager state

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ source code by setting environment variables:
   `MOMENTUM_MACD_HIST_NORM_WEIGHT`: Weight applied when an indicator exceeds
   its threshold. All default to `1`.
 - `SLIPPAGE_PCT`: Estimated slippage percentage applied to each trade. Defaults to `0`.
-- `FEE_PCT`: Trading fee percentage deducted on entry and exit. Defaults to `0`.
+- `FEE_PCT`: Trading fee percentage deducted on entry and exit. Defaults to `0.001` (0.1%).
 
 - `PREDICT_SIGNAL_LOG_FREQ`: How often `predict_signal` emits info-level logs
   of the predicted class. Defaults to `100`. Set to `0` to silence per-iteration

--- a/tests/test_trade_manager.py
+++ b/tests/test_trade_manager.py
@@ -232,3 +232,14 @@ def test_close_trade_skips_when_profit_ratio_low(monkeypatch):
 
     tm.close_trade('ABC', 105.0, reason='Take-Profit')
     assert not tm.has_position('ABC')
+
+
+def test_state_persists_trade_fee_pct(tmp_path):
+    tm = TradeManager(starting_balance=1000, trade_fee_pct=0.01)
+    tm.STATE_FILE = str(tmp_path / "state.json")
+    tm.save_state()
+
+    tm_loaded = TradeManager(starting_balance=1000, trade_fee_pct=0.0)
+    tm_loaded.STATE_FILE = tm.STATE_FILE
+    tm_loaded.load_state()
+    assert tm_loaded.trade_fee_pct == pytest.approx(0.01)

--- a/trade_manager.py
+++ b/trade_manager.py
@@ -867,6 +867,7 @@ class TradeManager:
             "positions": self.positions,
             "trade_history": self.trade_history,
             "total_fees": self.total_fees,
+            "trade_fee_pct": self.trade_fee_pct,
             "peak_equity": self.peak_equity,
             "drawdown_pct": self.drawdown_pct,
             "current_day": self.current_day,
@@ -892,6 +893,7 @@ class TradeManager:
             self.positions = state.get("positions", {})
             self.trade_history = state.get("trade_history", [])
             self.total_fees = state.get("total_fees", 0.0)
+            self.trade_fee_pct = state.get("trade_fee_pct", self.trade_fee_pct)
             self.peak_equity = state.get("peak_equity", self.balance)
             self.drawdown_pct = state.get("drawdown_pct", 0.0)
             self.current_day = state.get("current_day", time.strftime("%Y-%m-%d"))


### PR DESCRIPTION
## Summary
- verify FEE_PCT defaults to Binance's 0.1% trading fee
- store `trade_fee_pct` in TradeManager state for traceability
- document default trading fee

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689e721c23f8832cbf00693844f472ed