### PR TITLE
Check blacklist for candidates

### DIFF
--- a/symbol_resolver.py
+++ b/symbol_resolver.py
@@ -2,6 +2,7 @@ import requests
 
 from utils.logging import get_logger
 from config import MIN_SYMBOL_WIN_RATE, MIN_SYMBOL_AVG_PNL
+from analytics import performance as perf_utils
 
 logger = get_logger(__name__)
 
@@ -120,6 +121,16 @@ def filter_candidates(movers, open_symbols, performance):
                     f"⏭️ Skipping {symbol}: win rate {perf['win_rate']:.2f}% below {MIN_SYMBOL_WIN_RATE}%"
                 )
                 continue
+
+            holding_times = perf.get("holding_times")
+            if holding_times:
+                avg_hold = sum(holding_times) / len(holding_times)
+                duration_bucket = perf_utils.get_duration_bucket(avg_hold)
+                if perf_utils.is_blacklisted(symbol, duration_bucket):
+                    logger.info(
+                        f"⏭️ Skipping {symbol}: blacklisted for duration {duration_bucket}"
+                    )
+                    continue
 
         candidates.append((coin_id, symbol, name))
 

--- a/tests/test_symbol_resolver.py
+++ b/tests/test_symbol_resolver.py
@@ -2,6 +2,7 @@ import pytest
 
 from config import MIN_SYMBOL_AVG_PNL, MIN_SYMBOL_WIN_RATE
 from symbol_resolver import filter_candidates
+import analytics.performance as perf_utils
 
 
 def test_filter_candidates_enforces_thresholds():
@@ -21,3 +22,35 @@ def test_filter_candidates_enforces_thresholds():
 
     result = filter_candidates(movers, set(), performance)
     assert result == [("id1", "AAA", "AAA Coin")]
+
+
+def test_filter_candidates_skips_blacklisted(monkeypatch):
+    movers = [
+        ("id1", "AAA", "AAA Coin", 10.0),
+        ("id2", "BBB", "BBB Coin", 5.0),
+    ]
+    performance = {
+        "AAA": {
+            "avg_pnl": MIN_SYMBOL_AVG_PNL + 0.1,
+            "win_rate": MIN_SYMBOL_WIN_RATE + 10,
+            "holding_times": [120],
+        },
+        "BBB": {
+            "avg_pnl": MIN_SYMBOL_AVG_PNL + 0.1,
+            "win_rate": MIN_SYMBOL_WIN_RATE + 10,
+            "holding_times": [120],
+        },
+    }
+
+    calls = []
+
+    def fake_blacklisted(symbol, bucket):
+        calls.append((symbol, bucket))
+        return symbol == "AAA" and bucket == "1-5m"
+
+    monkeypatch.setattr(perf_utils, "is_blacklisted", fake_blacklisted)
+
+    result = filter_candidates(movers, set(), performance)
+    assert result == [("id2", "BBB", "BBB Coin")]
+    expected_bucket = perf_utils.get_duration_bucket(120)
+    assert ("AAA", expected_bucket) in calls


### PR DESCRIPTION
## Summary
- Skip blacklisted symbols during candidate filtering by deriving holding-time buckets and consulting `analytics.performance`
- Test coverage ensures blacklisted symbols are excluded

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a3ef8e1b3c832cb4785b65dd67b601