### PR TITLE
Increase minimum profit-to-fee ratio threshold

### DIFF
--- a/config.py
+++ b/config.py
@@ -75,7 +75,7 @@ FEE_PCT = float(os.getenv("FEE_PCT", "0.001"))
 
 # Minimum acceptable ratio of expected profit to total fees for a trade.
 # Trades falling below this profit-to-fee threshold will be skipped.
-MIN_PROFIT_FEE_RATIO = float(os.getenv("MIN_PROFIT_FEE_RATIO", "2.0"))
+MIN_PROFIT_FEE_RATIO = float(os.getenv("MIN_PROFIT_FEE_RATIO", "3.0"))
 
 # Number of bars to delay trade execution in backtests to model latency.
 EXECUTION_DELAY_BARS = int(os.getenv("EXECUTION_DELAY_BARS", "0"))

--- a/tests/test_trade_manager.py
+++ b/tests/test_trade_manager.py
@@ -4,7 +4,7 @@ import numpy as np
 import logging
 
 from trade_manager import TradeManager
-from config import ATR_MULT_SL
+from config import ATR_MULT_SL, MIN_PROFIT_FEE_RATIO
 
 
 def create_tm():
@@ -146,7 +146,7 @@ def test_skips_trade_when_profit_insufficient(monkeypatch):
     tm = create_tm()
     tm.risk_per_trade = 1.0
     tm.trade_fee_pct = 0.01
-    tm.min_profit_fee_ratio = 2.0
+    tm.min_profit_fee_ratio = MIN_PROFIT_FEE_RATIO
 
     df = pd.DataFrame({'ATR': [0.01]})
     monkeypatch.setattr('data_fetcher.fetch_ohlcv_smart', lambda *a, **k: df)
@@ -276,7 +276,8 @@ def test_losing_position_does_not_trigger_trailing_stop(monkeypatch):
 
 
 def test_close_trade_skips_when_profit_ratio_low(monkeypatch):
-    tm = TradeManager(starting_balance=1000, trade_fee_pct=0.01, min_profit_fee_ratio=2.0, hold_period_sec=0)
+    tm = TradeManager(starting_balance=1000, trade_fee_pct=0.01,
+                      min_profit_fee_ratio=MIN_PROFIT_FEE_RATIO, hold_period_sec=0)
     tm.positions['ABC'] = {
         'coin_id': 'abc',
         'entry_price': 100.0,
@@ -298,7 +299,7 @@ def test_close_trade_skips_when_profit_ratio_low(monkeypatch):
     tm.close_trade('ABC', 100.5, reason='Take-Profit')
     assert tm.has_position('ABC')
 
-    tm.close_trade('ABC', 105.0, reason='Take-Profit')
+    tm.close_trade('ABC', 107.0, reason='Take-Profit')
     assert not tm.has_position('ABC')
 
 


### PR DESCRIPTION
## Summary
- Raise default `MIN_PROFIT_FEE_RATIO` to 3.0 in `config.py`
- Update tests to reference the new constant and adjust expectations

## Testing
- `PYTHONPATH=. pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a3ef8ec334832c91e39fdd5ab14db5