### PR TITLE
Add configurable minimum hold duration bucket

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,11 @@ source code by setting environment variables:
   its threshold. All default to `1`.
 - `SLIPPAGE_PCT`: Estimated slippage percentage applied to each trade. Defaults to `0`.
 - `FEE_PCT`: Trading fee percentage deducted on entry and exit. Defaults to `0.001` (0.1%).
+- `MIN_HOLD_BUCKET`: Minimum trade duration bucket that must be reached before a
+  position can be closed without exceptional profit. Accepts labels such as
+  `<1m`, `1-5m`, `5-30m`, `30m-2h`, and `>2h`. Defaults to `">2h"`.
+- `EARLY_EXIT_FEE_MULT`: Profit-to-fee multiple required to exit a trade before
+  reaching `MIN_HOLD_BUCKET`. Defaults to `3`.
 
 - `PREDICT_SIGNAL_LOG_FREQ`: How often `predict_signal` emits info-level logs
   of the predicted class. Defaults to `100`. Set to `0` to silence per-iteration

--- a/config.py
+++ b/config.py
@@ -117,6 +117,15 @@ HOLDING_PERIOD_BARS = int(os.getenv("HOLDING_PERIOD_BARS", "0"))
 # Minimum seconds to wait after a trade before opening a new one in live trading.
 HOLDING_PERIOD_SECONDS = int(os.getenv("HOLDING_PERIOD_SECONDS", "300"))
 
+# Minimum trade duration bucket required before exits are allowed without
+# exceptional profitability. Uses labels from
+# ``analytics.performance.get_duration_bucket``.
+MIN_HOLD_BUCKET = os.getenv("MIN_HOLD_BUCKET", ">2h")
+
+# Profit-to-fee multiple required to exit a trade before reaching
+# ``MIN_HOLD_BUCKET``.
+EARLY_EXIT_FEE_MULT = float(os.getenv("EARLY_EXIT_FEE_MULT", "3"))
+
 # Additional confidence required before reversing an open position.
 REVERSAL_CONF_DELTA = float(os.getenv("REVERSAL_CONF_DELTA", "0"))
 


### PR DESCRIPTION
## Summary
- add `MIN_HOLD_BUCKET` and `EARLY_EXIT_FEE_MULT` settings
- gate early trade exits on profit multiple of fees before configured hold bucket
- enforce hold bucket in symbol filtering and document new options

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a3f105208c832c99c80a8e4d40a78d