### PR TITLE
Increase default hold period to five minutes

### DIFF
--- a/backtester.py
+++ b/backtester.py
@@ -20,6 +20,7 @@ from config import (
     EXECUTION_PRICE_WEIGHT,
     HOLDING_PERIOD_BARS,
     REVERSAL_CONF_DELTA,
+    HOLDING_PERIOD_SECONDS,
 )
 from trade_manager import TradeManager
 
@@ -249,7 +250,12 @@ def _simulate_trades(
         return metrics
 
     # === TradeManager-powered simulation ===
-    tm = TradeManager(starting_balance=1000, trade_fee_pct=fee_pct, slippage_pct=slippage_pct)
+    tm = TradeManager(
+        starting_balance=1000,
+        trade_fee_pct=fee_pct,
+        slippage_pct=slippage_pct,
+        hold_period_sec=HOLDING_PERIOD_SECONDS,
+    )
     equity_curve = []
     returns = []
     max_exposure = 0.0

--- a/config.py
+++ b/config.py
@@ -115,7 +115,8 @@ MIN_SYMBOL_AVG_PNL = float(os.getenv("MIN_SYMBOL_AVG_PNL", "0.05"))
 HOLDING_PERIOD_BARS = int(os.getenv("HOLDING_PERIOD_BARS", "0"))
 
 # Minimum seconds to wait after a trade before opening a new one in live trading.
-HOLDING_PERIOD_SECONDS = int(os.getenv("HOLDING_PERIOD_SECONDS", "300"))
+# Enforce a minimum of 5 minutes to bucket trades more coarsely.
+HOLDING_PERIOD_SECONDS = max(300, int(os.getenv("HOLDING_PERIOD_SECONDS", "300")))
 
 # Minimum trade duration bucket required before exits are allowed without
 # exceptional profitability. Uses labels from

--- a/main.py
+++ b/main.py
@@ -25,6 +25,7 @@ from config import (
     HIGH_CONF_BUY_OVERRIDE,
     VERY_HIGH_CONF_BUY_OVERRIDE,
     MIN_VOLATILITY_7D,
+    HOLDING_PERIOD_SECONDS,
 )
 from exchange_adapter import BinancePaperTradeAdapter
 from threshold_utils import get_dynamic_threshold
@@ -91,7 +92,7 @@ if TRADING_MODE == "paper":
 else:
     exchange = None
 
-tm = TradeManager(exchange=exchange)
+tm = TradeManager(exchange=exchange, hold_period_sec=HOLDING_PERIOD_SECONDS)
 tm.load_state()
 
 # ✅ Background thread for monitoring existing trades

--- a/tests/test_trade_manager.py
+++ b/tests/test_trade_manager.py
@@ -4,7 +4,7 @@ import numpy as np
 import logging
 
 from trade_manager import TradeManager
-from config import ATR_MULT_SL, MIN_PROFIT_FEE_RATIO
+from config import ATR_MULT_SL, MIN_PROFIT_FEE_RATIO, HOLDING_PERIOD_SECONDS
 
 
 def create_tm():
@@ -103,7 +103,7 @@ def test_slippage_applied_to_trade(monkeypatch):
 
 
 def test_hold_period_delays_exits(monkeypatch):
-    tm = TradeManager(starting_balance=1000, hold_period_sec=60, min_hold_bucket="<1m")
+    tm = TradeManager(starting_balance=1000, hold_period_sec=HOLDING_PERIOD_SECONDS, min_hold_bucket="<1m")
     tm.risk_per_trade = 1.0
     tm.slippage_pct = 0.0
     tm.trade_fee_pct = 0.0
@@ -119,7 +119,7 @@ def test_hold_period_delays_exits(monkeypatch):
     assert tm.has_position('ABC')
 
     # After hold period elapsed, manage should close on the same price
-    tm.positions['ABC']['entry_time'] -= 61
+    tm.positions['ABC']['entry_time'] -= HOLDING_PERIOD_SECONDS + 1
     tm.manage('ABC', pos['stop_loss'] - 0.01)
     assert not tm.has_position('ABC')
 
@@ -189,7 +189,7 @@ def test_open_trade_respects_confidence_threshold(monkeypatch):
 
 
 def test_open_trade_enforces_hold_period(monkeypatch):
-    tm = TradeManager(starting_balance=1000, hold_period_sec=60, min_hold_bucket="<1m")
+    tm = TradeManager(starting_balance=1000, hold_period_sec=HOLDING_PERIOD_SECONDS, min_hold_bucket="<1m")
     tm.risk_per_trade = 0.5
     tm.min_trade_usd = 0
     tm.slippage_pct = 0.0
@@ -202,7 +202,7 @@ def test_open_trade_enforces_hold_period(monkeypatch):
     tm.open_trade('DEF', 5.0, confidence=1.0)
     assert 'DEF' not in tm.positions
 
-    tm.last_trade_time -= 61
+    tm.last_trade_time -= HOLDING_PERIOD_SECONDS + 1
     tm.open_trade('DEF', 5.0, confidence=1.0)
     assert 'DEF' in tm.positions
 
@@ -324,7 +324,7 @@ def test_state_persists_trade_fee_pct(tmp_path):
 
 
 def test_blacklist_skips_trade(monkeypatch):
-    tm = TradeManager(starting_balance=1000, hold_period_sec=300, min_hold_bucket="5-30m")
+    tm = TradeManager(starting_balance=1000, hold_period_sec=HOLDING_PERIOD_SECONDS, min_hold_bucket="5-30m")
     tm.risk_per_trade = 1.0
     tm.min_trade_usd = 0
     tm.slippage_pct = 0.0


### PR DESCRIPTION
## Summary
- Enforce a minimum five-minute holding period and thread it through config
- Pass holding period to TradeManager instances in main and backtester modules
- Update TradeManager tests to respect the new holding period

## Testing
- `PYTHONPATH=. pytest tests/test_trade_manager.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68ab82f48360832cbb87859a80456d64