### PR TITLE
Add safeguard for trade rotation based on net gain

### DIFF
--- a/tests/test_trade_manager.py
+++ b/tests/test_trade_manager.py
@@ -64,6 +64,7 @@ def test_close_trade_records_rotation_price(monkeypatch):
     assert record['rotation_exit_price'] == pytest.approx(12.0)
     assert record['rotation_projected_gain'] > 0
     assert record['rotation_cost'] == pytest.approx(0.0)
+    assert record['rotation_net_gain'] == pytest.approx(record['rotation_projected_gain'])
 
 
 def test_rotation_aborted_when_gain_insufficient(monkeypatch):
@@ -82,6 +83,25 @@ def test_rotation_aborted_when_gain_insufficient(monkeypatch):
     assert closed is False
     assert 'ABC' in tm.positions
     assert len(tm.trade_history) == 0
+
+
+def test_rotation_executes_when_gain_covers_cost(monkeypatch):
+    tm = create_tm()
+    tm.risk_per_trade = 1.0
+    df = mock_indicator_df()
+    monkeypatch.setattr('data_fetcher.fetch_ohlcv_smart', lambda *a, **k: df)
+    monkeypatch.setattr('feature_engineer.add_indicators', lambda d: d)
+    tm.open_trade('ABC', 10.0, confidence=1.0)
+    closed = tm.close_trade(
+        'ABC',
+        9.0,
+        reason='Rotated to better candidate',
+        candidate={'symbol': 'XYZ', 'price': 5.0, 'confidence': 2.0},
+    )
+    assert closed is True
+    assert 'ABC' not in tm.positions
+    record = tm.trade_history[-1]
+    assert record['rotation_net_gain'] == pytest.approx(80.0)
 
 
 def test_slippage_applied_to_trade(monkeypatch):

--- a/trade_manager.py
+++ b/trade_manager.py
@@ -533,6 +533,7 @@ class TradeManager:
 
         rotation_projected_gain = None
         rotation_cost_est = None
+        rotation_net_gain_est = None
         if reason == "Rotated to better candidate" and candidate:
             rotation_projected_gain = self._estimate_rotation_gain(
                 candidate.get("price"),
@@ -545,16 +546,17 @@ class TradeManager:
             else:
                 raw_loss = max(0, (current_price - entry_price) * qty)
             rotation_cost_est = raw_loss + entry_fee + exit_fee_est
+            rotation_net_gain_est = rotation_projected_gain - rotation_cost_est
             logger.info(
-                "🔄 Rotation check: projected gain $%.2f vs cost $%.2f",
+                "🔄 Rotation check: projected gain $%.2f vs cost $%.2f => net $%.2f",
                 rotation_projected_gain,
                 rotation_cost_est,
+                rotation_net_gain_est,
             )
-            if rotation_projected_gain <= rotation_cost_est:
+            if rotation_net_gain_est <= 0:
                 logger.info(
-                    "❌ Rotation aborted: projected gain $%.2f <= cost $%.2f",
-                    rotation_projected_gain,
-                    rotation_cost_est,
+                    "❌ Rotation aborted: net gain $%.2f <= 0",
+                    rotation_net_gain_est,
                 )
                 return False
 
@@ -651,6 +653,7 @@ class TradeManager:
             if rotation_projected_gain is not None:
                 trade_record["rotation_projected_gain"] = rotation_projected_gain
                 trade_record["rotation_cost"] = rotation_cost_actual
+                trade_record["rotation_net_gain"] = rotation_projected_gain - rotation_cost_actual
                 trade_record["rotation_candidate"] = candidate.get("symbol") if candidate else None
 
         self.trade_history.append(trade_record)


### PR DESCRIPTION
## Summary
- compute projected gain for rotation candidates and compare with current position's loss and fees
- record rotation net gain in trade history
- add tests for rotation guard and positive-net rotation

## Testing
- `PYTHONPATH=. pytest tests/test_trade_manager.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68ab82f019f4832c88b428023d24fc67