### PR TITLE
Raise min profit fee ratio and enforce in rotations

### DIFF
--- a/config.py
+++ b/config.py
@@ -75,7 +75,9 @@ FEE_PCT = float(os.getenv("FEE_PCT", "0.001"))
 
 # Minimum acceptable ratio of expected profit to total fees for a trade.
 # Trades falling below this profit-to-fee threshold will be skipped.
-MIN_PROFIT_FEE_RATIO = float(os.getenv("MIN_PROFIT_FEE_RATIO", "3.0"))
+# Raised to a more conservative default of 5.0 to ensure trades offer
+# sufficient edge over fees before execution.
+MIN_PROFIT_FEE_RATIO = float(os.getenv("MIN_PROFIT_FEE_RATIO", "5.0"))
 
 # Number of bars to delay trade execution in backtests to model latency.
 EXECUTION_DELAY_BARS = int(os.getenv("EXECUTION_DELAY_BARS", "0"))

--- a/tests/test_trade_manager.py
+++ b/tests/test_trade_manager.py
@@ -308,7 +308,7 @@ def test_close_trade_skips_when_profit_ratio_low(monkeypatch):
     tm.close_trade('ABC', 100.5, reason='Take-Profit')
     assert tm.has_position('ABC')
 
-    tm.close_trade('ABC', 107.0, reason='Take-Profit')
+    tm.close_trade('ABC', 111.0, reason='Take-Profit')
     assert not tm.has_position('ABC')
 
 

--- a/trade_manager.py
+++ b/trade_manager.py
@@ -160,7 +160,14 @@ class TradeManager:
             )
             est_exit_fee = est_take_profit * est_qty * self.trade_fee_pct
             expected_profit = (est_exec_price - est_take_profit) * est_qty
+
         total_est_fees = entry_fee_est + est_exit_fee
+        profit_fee_ratio = (
+            expected_profit / total_est_fees if total_est_fees > 0 else float("inf")
+        )
+        if profit_fee_ratio < self.min_profit_fee_ratio:
+            return 0.0
+
         return expected_profit - total_est_fees
 
     def _update_equity_metrics(self):


### PR DESCRIPTION
## Summary
- increase `MIN_PROFIT_FEE_RATIO` default to 5.0
- ensure rotation gain estimation respects minimum profit-to-fee threshold
- adjust trade manager tests for stricter profit requirement

## Testing
- `PYTHONPATH=. pytest tests/test_trade_manager.py`


------
https://chatgpt.com/codex/tasks/task_e_68ab82efe66c832c9f2f31898be5e88d