### PR TITLE
Increase profit-to-fee threshold for trades

### DIFF
--- a/config.py
+++ b/config.py
@@ -75,9 +75,9 @@ FEE_PCT = float(os.getenv("FEE_PCT", "0.001"))
 
 # Minimum acceptable ratio of expected profit to total fees for a trade.
 # Trades falling below this profit-to-fee threshold will be skipped.
-# Raised to a more conservative default of 5.0 to ensure trades offer
-# sufficient edge over fees before execution.
-MIN_PROFIT_FEE_RATIO = float(os.getenv("MIN_PROFIT_FEE_RATIO", "5.0"))
+# Bumped to a stricter default of 7.0 to demand greater edge over fees
+# before executing any position.
+MIN_PROFIT_FEE_RATIO = float(os.getenv("MIN_PROFIT_FEE_RATIO", "7.0"))
 
 # Number of bars to delay trade execution in backtests to model latency.
 EXECUTION_DELAY_BARS = int(os.getenv("EXECUTION_DELAY_BARS", "0"))

--- a/tests/test_trade_manager.py
+++ b/tests/test_trade_manager.py
@@ -328,7 +328,7 @@ def test_close_trade_skips_when_profit_ratio_low(monkeypatch):
     tm.close_trade('ABC', 100.5, reason='Take-Profit')
     assert tm.has_position('ABC')
 
-    tm.close_trade('ABC', 111.0, reason='Take-Profit')
+    tm.close_trade('ABC', 120.0, reason='Take-Profit')
     assert not tm.has_position('ABC')
 
 
@@ -364,7 +364,7 @@ def test_blacklist_skips_trade(monkeypatch):
 
 
 def test_fee_ratio_blacklist(monkeypatch):
-    tm = TradeManager(starting_balance=1000, hold_period_sec=10, min_hold_bucket="<1m")
+    tm = TradeManager(starting_balance=1000, hold_period_sec=10, min_hold_bucket="30m-2h")
     tm.risk_per_trade = 1.0
     tm.min_trade_usd = 0
     tm.slippage_pct = 0.0
@@ -374,6 +374,6 @@ def test_fee_ratio_blacklist(monkeypatch):
     monkeypatch.setattr('data_fetcher.fetch_ohlcv_smart', lambda *a, **k: df)
     monkeypatch.setattr('feature_engineer.add_indicators', lambda d: d)
 
-    # DOGE with <1m bucket has a positive PnL but excessive fee ratio in stats
-    tm.open_trade('DOGE', 10.0, confidence=1.0)
-    assert 'DOGE' not in tm.positions
+    # LINK in the 30m-2h bucket is blacklisted due to historical fee ratio
+    tm.open_trade('LINK', 10.0, confidence=1.0)
+    assert 'LINK' not in tm.positions

--- a/trade_manager.py
+++ b/trade_manager.py
@@ -18,7 +18,7 @@ from config import (
     FEE_PCT,
     HOLDING_PERIOD_SECONDS,
     REVERSAL_CONF_DELTA,
-    MIN_PROFIT_FEE_RATIO,
+    MIN_PROFIT_FEE_RATIO,  # Higher profit-to-fee requirement
     CONFIDENCE_THRESHOLD,
     BLACKLIST_REFRESH_SEC,
     MIN_HOLD_BUCKET,
@@ -66,7 +66,7 @@ class TradeManager:
                  slippage_pct=SLIPPAGE_PCT,
                  hold_period_sec=HOLDING_PERIOD_SECONDS,
                  reverse_conf_delta=REVERSAL_CONF_DELTA,
-                 min_profit_fee_ratio=MIN_PROFIT_FEE_RATIO,
+                 min_profit_fee_ratio=MIN_PROFIT_FEE_RATIO,  # Enforce stricter profit threshold
                  trail_profit_fee_ratio=2.0,
                  exchange=None,
                  blacklist_refresh_sec=BLACKLIST_REFRESH_SEC,


### PR DESCRIPTION
## Summary
- bump default `MIN_PROFIT_FEE_RATIO` to 7.0 so trades must offer greater profit over fees
- document and propagate stricter threshold in `TradeManager`
- update unit tests for new ratio and blacklist scenario

## Testing
- `pytest`
- `python - <<'PY'
from trade_manager import TradeManager
from config import MIN_PROFIT_FEE_RATIO
old_tm = TradeManager(starting_balance=1000, min_profit_fee_ratio=5)
new_tm = TradeManager(starting_balance=1000, min_profit_fee_ratio=MIN_PROFIT_FEE_RATIO)
for tm in (old_tm, new_tm):
    tm.risk_per_trade = 1.0
    tm.trade_fee_pct = 0.01
    gain = tm._estimate_rotation_gain(10.0, confidence=1.0)
    print(f"min_ratio={tm.min_profit_fee_ratio}, estimated_gain={gain:.2f}")
PY`

------
https://chatgpt.com/codex/tasks/task_e_68ad13194d80832cba4988471e6aadb7