### PR TITLE
Apply minimum trade count before blacklisting pairs

### DIFF
--- a/analytics/performance.py
+++ b/analytics/performance.py
@@ -1,7 +1,7 @@
 import csv
 import os
 import time
-from typing import Set, Tuple
+from typing import Dict, Set, Tuple
 
 # Default location for the trade statistics CSV
 DEFAULT_STATS_FILE = os.path.join(os.path.dirname(__file__), "trade_stats.csv")
@@ -9,44 +9,55 @@ DEFAULT_STATS_FILE = os.path.join(os.path.dirname(__file__), "trade_stats.csv")
 # Maximum acceptable fees relative to PnL before blacklisting
 FEE_RATIO_THRESHOLD = 1.0
 
-# Cached blacklist and timestamp of last refresh
+# Minimum number of trades required before considering a pair for blacklisting
+MIN_TRADE_COUNT = 3
+
+# Cached blacklist, trade counts, and timestamp of last refresh
 _blacklist: Set[Tuple[str, str]] = set()
+_trade_counts: Dict[Tuple[str, str], int] = {}
 _last_loaded: float = 0.0
 
 
-def _parse_stats(path: str) -> Set[Tuple[str, str]]:
-    """Parse the trade stats CSV and return blacklist pairs.
+def _parse_stats(path: str) -> Tuple[Set[Tuple[str, str]], Dict[Tuple[str, str], int]]:
+    """Parse the trade stats CSV and return blacklist pairs and trade counts.
 
     A pair ``(symbol, duration_bucket)`` is blacklisted when the win rate is 0,
     the average PnL is negative, or the ``fee_ratio`` exceeds
-    :data:`FEE_RATIO_THRESHOLD`.
+    :data:`FEE_RATIO_THRESHOLD`, *and* it has at least
+    :data:`MIN_TRADE_COUNT` trades.
     """
     pairs: Set[Tuple[str, str]] = set()
+    counts: Dict[Tuple[str, str], int] = {}
     if not os.path.exists(path):
-        return pairs
+        return pairs, counts
 
     with open(path, newline="") as f:
         reader = csv.DictReader(f)
         for row in reader:
             try:
+                trade_count = int(row.get("trade_count", 0))
                 win_rate = float(row.get("win_rate", 0))
                 avg_pnl = float(row.get("avg_pnl", 0))
                 fee_ratio = float(row.get("fee_ratio", 0))
             except (TypeError, ValueError):
                 continue
-            if win_rate == 0 or avg_pnl < 0 or fee_ratio > FEE_RATIO_THRESHOLD:
-                symbol = row.get("symbol", "").upper()
-                bucket = row.get("duration_bucket", "")
+            symbol = row.get("symbol", "").upper()
+            bucket = row.get("duration_bucket", "")
+            counts[(symbol, bucket)] = trade_count
+            if (
+                trade_count >= MIN_TRADE_COUNT
+                and (win_rate == 0 or avg_pnl < 0 or fee_ratio > FEE_RATIO_THRESHOLD)
+            ):
                 pairs.add((symbol, bucket))
-    return pairs
+    return pairs, counts
 
 
 def load_blacklist(path: str = DEFAULT_STATS_FILE, refresh_seconds: int = 3600) -> Set[Tuple[str, str]]:
     """Return cached blacklist, reloading from CSV when stale."""
-    global _blacklist, _last_loaded
+    global _blacklist, _trade_counts, _last_loaded
     now = time.time()
     if not _blacklist or now - _last_loaded > refresh_seconds:
-        _blacklist = _parse_stats(path)
+        _blacklist, _trade_counts = _parse_stats(path)
         _last_loaded = now
     return _blacklist
 
@@ -60,6 +71,17 @@ def is_blacklisted(
     """Return True if the symbol and duration bucket are blacklisted."""
     bl = load_blacklist(path, refresh_seconds)
     return (symbol.upper(), duration_bucket) in bl
+
+
+def get_trade_count(
+    symbol: str,
+    duration_bucket: str,
+    path: str = DEFAULT_STATS_FILE,
+    refresh_seconds: int = 3600,
+) -> int:
+    """Return the trade count for the given symbol and duration bucket."""
+    load_blacklist(path, refresh_seconds)
+    return _trade_counts.get((symbol.upper(), duration_bucket), 0)
 
 
 def get_duration_bucket(seconds: float) -> str:
@@ -77,6 +99,7 @@ def get_duration_bucket(seconds: float) -> str:
 
 def reset_cache() -> None:
     """Clear cached blacklist (primarily for tests)."""
-    global _blacklist, _last_loaded
+    global _blacklist, _trade_counts, _last_loaded
     _blacklist = set()
+    _trade_counts = {}
     _last_loaded = 0.0

--- a/analytics/trade_stats.csv
+++ b/analytics/trade_stats.csv
@@ -1,4 +1,5 @@
 symbol,duration_bucket,trade_count,win_rate,avg_pnl,fee_ratio
+DOGE,<1m,3,100.0,0.05,1.5
 ETH,<1m,3,33.33,-0.03,0.7453
 LINK,30m-2h,1,0.0,-0.03,6.519
 ETC,>2h,1,100.0,0.4,0.4706

--- a/tests/test_performance.py
+++ b/tests/test_performance.py
@@ -1,0 +1,17 @@
+import analytics.performance as perf
+
+def test_blacklist_respects_trade_count_threshold(tmp_path):
+    csv_path = tmp_path / "stats.csv"
+    csv_path.write_text(
+        "symbol,duration_bucket,trade_count,win_rate,avg_pnl,fee_ratio\n"
+        "AAA,1-5m,2,0.0,-0.5,0.0\n"
+        "BBB,1-5m,3,0.0,-0.5,0.0\n"
+    )
+    perf.reset_cache()
+    assert not perf.is_blacklisted("AAA", "1-5m", path=str(csv_path), refresh_seconds=0)
+    assert perf.is_blacklisted("BBB", "1-5m", path=str(csv_path), refresh_seconds=0)
+
+
+def test_get_trade_count_reads_from_stats():
+    perf.reset_cache()
+    assert perf.get_trade_count("INJ", "5-30m", refresh_seconds=0) == 3


### PR DESCRIPTION
## Summary
- Track trade counts per (symbol, duration bucket) and expose `get_trade_count`
- Require a minimum number of trades before blacklisting combinations with poor performance
- Add high-fee DOGE trade stats and tests covering trade count threshold

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68ad131c1f3c832ca38735641648465b