### PR TITLE
Persist closed PnL history in TradeManager state

### DIFF
--- a/tests/test_trade_manager.py
+++ b/tests/test_trade_manager.py
@@ -425,6 +425,18 @@ def test_state_persists_trade_fee_pct(tmp_path):
     assert tm_loaded.trade_fee_pct == pytest.approx(0.01)
 
 
+def test_state_persists_closed_pnl_history(tmp_path):
+    tm = TradeManager(starting_balance=1000)
+    tm.closed_pnl_history = [5.0, -3.0]
+    tm.STATE_FILE = str(tmp_path / "state.json")
+    tm.save_state()
+
+    tm_loaded = TradeManager(starting_balance=1000)
+    tm_loaded.STATE_FILE = tm.STATE_FILE
+    tm_loaded.load_state()
+    assert tm_loaded.closed_pnl_history == [5.0, -3.0]
+
+
 def test_blacklist_skips_trade(monkeypatch):
     tm = TradeManager(starting_balance=1000, hold_period_sec=HOLDING_PERIOD_SECONDS, min_hold_bucket="5-30m")
     tm.risk_per_trade = 1.0

--- a/trade_manager.py
+++ b/trade_manager.py
@@ -1103,6 +1103,7 @@ class TradeManager:
             "balance": self.balance,
             "positions": self.positions,
             "trade_history": self.trade_history,
+            "closed_pnl_history": self.closed_pnl_history,
             "total_fees": self.total_fees,
             "trade_fee_pct": self.trade_fee_pct,
             "peak_equity": self.peak_equity,
@@ -1129,6 +1130,7 @@ class TradeManager:
             self.balance = state.get("balance", self.starting_balance)
             self.positions = state.get("positions", {})
             self.trade_history = state.get("trade_history", [])
+            self.closed_pnl_history = state.get("closed_pnl_history", [])
             self.total_fees = state.get("total_fees", 0.0)
             self.trade_fee_pct = state.get("trade_fee_pct", self.trade_fee_pct)
             self.peak_equity = state.get("peak_equity", self.balance)


### PR DESCRIPTION
## Summary
- include `closed_pnl_history` when saving TradeManager state
- restore `closed_pnl_history` from saved state with default empty list
- add regression test for closed PnL history persistence

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ad31c49740832c880bab0580043780