### PR TITLE
Expose stagnation settings via config

### DIFF
--- a/config.py
+++ b/config.py
@@ -79,6 +79,12 @@ FEE_PCT = float(os.getenv("FEE_PCT", "0.001"))
 # before executing any position.
 MIN_PROFIT_FEE_RATIO = float(os.getenv("MIN_PROFIT_FEE_RATIO", "7.0"))
 
+# Price stagnation detection parameters. If price movement stays below
+# ``STAGNATION_THRESHOLD_PCT`` for ``STAGNATION_DURATION_SEC`` seconds, the
+# position will be closed.
+STAGNATION_THRESHOLD_PCT = float(os.getenv("STAGNATION_THRESHOLD_PCT", "0.005"))
+STAGNATION_DURATION_SEC = int(os.getenv("STAGNATION_DURATION_SEC", "1800"))
+
 # Allocation scaling parameters for drawdown control.
 ALLOCATION_MAX_DD = float(os.getenv("ALLOCATION_MAX_DD", "0.10"))
 ALLOCATION_MIN_FACTOR = float(os.getenv("ALLOCATION_MIN_FACTOR", "0.5"))

--- a/tests/test_trade_manager.py
+++ b/tests/test_trade_manager.py
@@ -10,6 +10,8 @@ from config import (
     HOLDING_PERIOD_SECONDS,
     ALLOCATION_MAX_DD,
     ALLOCATION_MIN_FACTOR,
+    STAGNATION_THRESHOLD_PCT,
+    STAGNATION_DURATION_SEC,
 )
 
 
@@ -228,8 +230,8 @@ def test_stagnation_closes_position(monkeypatch):
     tm = TradeManager(
         starting_balance=1000,
         hold_period_sec=0,
-        stagnation_threshold_pct=0.005,
-        stagnation_duration_sec=10,
+        stagnation_threshold_pct=STAGNATION_THRESHOLD_PCT,
+        stagnation_duration_sec=STAGNATION_DURATION_SEC,
         min_hold_bucket="<1m",
     )
     tm.risk_per_trade = 1.0
@@ -245,10 +247,10 @@ def test_stagnation_closes_position(monkeypatch):
     assert pos['entry_price'] == pytest.approx(100.0)
     assert pos['entry_time'] > 0
 
-    pos['entry_time'] -= 11
-    pos['last_movement_time'] -= 11
+    pos['entry_time'] -= STAGNATION_DURATION_SEC + 1
+    pos['last_movement_time'] -= STAGNATION_DURATION_SEC + 1
 
-    tm.manage('ABC', pos['entry_price'] * 1.001)
+    tm.manage('ABC', pos['entry_price'] * (1 + STAGNATION_THRESHOLD_PCT / 2))
     assert 'ABC' not in tm.positions
     assert tm.trade_history[-1]['reason'] == 'Stagnant Price'
 

--- a/trade_manager.py
+++ b/trade_manager.py
@@ -25,6 +25,8 @@ from config import (
     EARLY_EXIT_FEE_MULT,
     ALLOCATION_MAX_DD,
     ALLOCATION_MIN_FACTOR,
+    STAGNATION_THRESHOLD_PCT,
+    STAGNATION_DURATION_SEC,
 )
 
 from utils.logging import get_logger
@@ -77,8 +79,8 @@ class TradeManager:
                  blacklist_refresh_sec=BLACKLIST_REFRESH_SEC,
                  min_hold_bucket=MIN_HOLD_BUCKET,
                  early_exit_fee_mult=EARLY_EXIT_FEE_MULT,
-                 stagnation_threshold_pct=0.005,
-                 stagnation_duration_sec=30 * 60):
+                 stagnation_threshold_pct=STAGNATION_THRESHOLD_PCT,
+                 stagnation_duration_sec=STAGNATION_DURATION_SEC):
         self.starting_balance = starting_balance
         self.balance = starting_balance
         self.max_allocation = max_allocation


### PR DESCRIPTION
## Summary
- add `STAGNATION_THRESHOLD_PCT` and `STAGNATION_DURATION_SEC` options in config
- default TradeManager stagnation parameters to values from config
- update tests to use config for stagnation settings

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ad31c62808832c8fa36feb67ff3cc1