### PR TITLE
feat: include unrealized pnl in equity metrics

### DIFF
--- a/config.py
+++ b/config.py
@@ -83,6 +83,10 @@ MIN_PROFIT_FEE_RATIO = float(os.getenv("MIN_PROFIT_FEE_RATIO", "7.0"))
 ALLOCATION_MAX_DD = float(os.getenv("ALLOCATION_MAX_DD", "0.10"))
 ALLOCATION_MIN_FACTOR = float(os.getenv("ALLOCATION_MIN_FACTOR", "0.5"))
 
+# Include unrealized PnL from open positions when computing equity metrics.
+# Disabled by default to preserve legacy realized-only behavior.
+INCLUDE_UNREALIZED_PNL = os.getenv("INCLUDE_UNREALIZED_PNL", "0") == "1"
+
 # Number of bars to delay trade execution in backtests to model latency.
 EXECUTION_DELAY_BARS = int(os.getenv("EXECUTION_DELAY_BARS", "0"))
 


### PR DESCRIPTION
## Summary
- add `INCLUDE_UNREALIZED_PNL` flag to optionally factor open trade PnL into equity calculations
- extend `TradeManager` to compute drawdowns using unrealized PnL when enabled
- test allocation scaling when unrealized losses drop equity

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68ad31d3e770832c942db145d4021120