### PR TITLE
Make performance thresholds configurable

### DIFF
--- a/analytics/performance.py
+++ b/analytics/performance.py
@@ -7,10 +7,12 @@ from typing import Dict, Set, Tuple
 DEFAULT_STATS_FILE = os.path.join(os.path.dirname(__file__), "trade_stats.csv")
 
 # Maximum acceptable fees relative to PnL before blacklisting
-FEE_RATIO_THRESHOLD = 1.0
+# Allow override via ``FEE_RATIO_THRESHOLD`` environment variable.
+FEE_RATIO_THRESHOLD = float(os.getenv("FEE_RATIO_THRESHOLD", "1.0"))
 
 # Minimum number of trades required before considering a pair for blacklisting
-MIN_TRADE_COUNT = 3
+# Allow override via ``MIN_TRADE_COUNT`` environment variable.
+MIN_TRADE_COUNT = int(os.getenv("MIN_TRADE_COUNT", "3"))
 
 # Cached blacklist, trade counts, and timestamp of last refresh
 _blacklist: Set[Tuple[str, str]] = set()

--- a/config.py
+++ b/config.py
@@ -151,5 +151,12 @@ EARLY_EXIT_FEE_MULT = float(os.getenv("EARLY_EXIT_FEE_MULT", "3"))
 REVERSAL_CONF_DELTA = float(os.getenv("REVERSAL_CONF_DELTA", "0"))
 
 
+# === Performance analytics configuration ===
+# Maximum acceptable fees relative to PnL before blacklisting a pair.
+PERF_FEE_RATIO_THRESHOLD = float(os.getenv("FEE_RATIO_THRESHOLD", "1.0"))
+
+# Minimum number of trades required before considering a pair for blacklisting.
+PERF_MIN_TRADE_COUNT = int(os.getenv("MIN_TRADE_COUNT", "3"))
+
 # Seconds before refreshing performance blacklist from analytics file.
 BLACKLIST_REFRESH_SEC = int(os.getenv("BLACKLIST_REFRESH_SEC", "3600"))

--- a/tests/test_performance.py
+++ b/tests/test_performance.py
@@ -1,11 +1,12 @@
 import analytics.performance as perf
+from config import PERF_MIN_TRADE_COUNT
 
 def test_blacklist_respects_trade_count_threshold(tmp_path):
     csv_path = tmp_path / "stats.csv"
     csv_path.write_text(
         "symbol,duration_bucket,trade_count,win_rate,avg_pnl,fee_ratio\n"
-        "AAA,1-5m,2,0.0,-0.5,0.0\n"
-        "BBB,1-5m,3,0.0,-0.5,0.0\n"
+        f"AAA,1-5m,{PERF_MIN_TRADE_COUNT - 1},0.0,-0.5,0.0\n"
+        f"BBB,1-5m,{PERF_MIN_TRADE_COUNT},0.0,-0.5,0.0\n"
     )
     perf.reset_cache()
     assert not perf.is_blacklisted("AAA", "1-5m", path=str(csv_path), refresh_seconds=0)

--- a/tests/test_trade_manager.py
+++ b/tests/test_trade_manager.py
@@ -12,7 +12,9 @@ from config import (
     ALLOCATION_MIN_FACTOR,
     STAGNATION_THRESHOLD_PCT,
     STAGNATION_DURATION_SEC,
+    PERF_MIN_TRADE_COUNT,
 )
+import analytics.performance as perf
 
 
 def create_tm(include_unrealized=False):
@@ -480,6 +482,11 @@ def test_blacklist_skips_trade(monkeypatch):
 
 
 def test_fee_ratio_blacklist(monkeypatch):
+    # Lower the trade count threshold so the LINK sample is eligible for blacklisting
+    monkeypatch.setattr("config.PERF_MIN_TRADE_COUNT", 1)
+    monkeypatch.setattr(perf, "MIN_TRADE_COUNT", max(1, PERF_MIN_TRADE_COUNT - 2))
+    perf.reset_cache()
+
     tm = TradeManager(starting_balance=1000, hold_period_sec=10, min_hold_bucket="30m-2h")
     tm.risk_per_trade = 1.0
     tm.min_trade_usd = 0


### PR DESCRIPTION
## Summary
- allow analytics performance module to read FEE_RATIO_THRESHOLD and MIN_TRADE_COUNT from environment
- expose PERF_FEE_RATIO_THRESHOLD and PERF_MIN_TRADE_COUNT in config for centralized management
- adjust tests to exercise and respect new configurable thresholds

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68ae8f62a070832c9ba339ecbaabc057