### PR TITLE
Add configurable drawdown and daily loss limits

### DIFF
--- a/config.py
+++ b/config.py
@@ -73,6 +73,12 @@ SLIPPAGE_PCT = float(os.getenv("SLIPPAGE_PCT", "0.001"))
 # to model exchange fees and is used as the default fee in TradeManager.
 FEE_PCT = float(os.getenv("FEE_PCT", "0.001"))
 
+# Maximum allowable account drawdown before trading stops.
+MAX_DRAWDOWN_PCT = float(os.getenv("MAX_DRAWDOWN_PCT", "0.20"))
+
+# Maximum daily loss tolerated before halting trading.
+MAX_DAILY_LOSS_PCT = float(os.getenv("MAX_DAILY_LOSS_PCT", "0.05"))
+
 # Minimum acceptable ratio of expected profit to total fees for a trade.
 # Trades falling below this profit-to-fee threshold will be skipped.
 # Bumped to a stricter default of 7.0 to demand greater edge over fees

--- a/tests/test_trade_manager.py
+++ b/tests/test_trade_manager.py
@@ -36,6 +36,27 @@ def mock_indicator_df():
     })
 
 
+def test_env_var_overrides_drawdown(monkeypatch):
+    import importlib
+    import config as config_module
+    import trade_manager as tm_module
+
+    monkeypatch.setenv("MAX_DRAWDOWN_PCT", "0.1")
+    monkeypatch.setenv("MAX_DAILY_LOSS_PCT", "0.02")
+
+    importlib.reload(config_module)
+    importlib.reload(tm_module)
+
+    tm = tm_module.TradeManager(starting_balance=1000, hold_period_sec=0, min_hold_bucket="<1m")
+    assert tm.max_drawdown_pct == pytest.approx(0.1)
+    assert tm.max_daily_loss_pct == pytest.approx(0.02)
+
+    monkeypatch.delenv("MAX_DRAWDOWN_PCT", raising=False)
+    monkeypatch.delenv("MAX_DAILY_LOSS_PCT", raising=False)
+    importlib.reload(config_module)
+    importlib.reload(tm_module)
+
+
 def test_calculate_allocation():
     tm = create_tm()
     alloc = tm.calculate_allocation(confidence=0.5)

--- a/trade_manager.py
+++ b/trade_manager.py
@@ -16,6 +16,8 @@ from config import (
     MIN_TRADE_USD,
     SLIPPAGE_PCT,
     FEE_PCT,
+    MAX_DRAWDOWN_PCT,
+    MAX_DAILY_LOSS_PCT,
     HOLDING_PERIOD_SECONDS,
     REVERSAL_CONF_DELTA,
     MIN_PROFIT_FEE_RATIO,  # Higher profit-to-fee requirement
@@ -78,7 +80,7 @@ class TradeManager:
                  trail_vol_mult=TRAIL_VOL_MULT,
                  atr_mult_sl=ATR_MULT_SL,
                  atr_mult_tp=ATR_MULT_TP,
-                 max_drawdown_pct=0.20, max_daily_loss_pct=0.05,
+                 max_drawdown_pct=MAX_DRAWDOWN_PCT, max_daily_loss_pct=MAX_DAILY_LOSS_PCT,
                  slippage_pct=SLIPPAGE_PCT,
                  hold_period_sec=HOLDING_PERIOD_SECONDS,
                  reverse_conf_delta=REVERSAL_CONF_DELTA,


### PR DESCRIPTION
## Summary
- Load `MAX_DRAWDOWN_PCT` and `MAX_DAILY_LOSS_PCT` from environment in `config.py`
- Use these configuration values as defaults in `TradeManager`
- Add test ensuring env var overrides correctly affect `TradeManager` settings

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ae9519a100832c8d25a77a0a13af66