### PR TITLE
Use config performance thresholds

### DIFF
--- a/tests/test_trade_manager.py
+++ b/tests/test_trade_manager.py
@@ -546,7 +546,7 @@ def test_blacklist_skips_trade(monkeypatch):
 def test_fee_ratio_blacklist(monkeypatch):
     # Lower the trade count threshold so the LINK sample is eligible for blacklisting
     monkeypatch.setattr("config.PERF_MIN_TRADE_COUNT", 1)
-    monkeypatch.setattr(perf, "MIN_TRADE_COUNT", max(1, PERF_MIN_TRADE_COUNT - 2))
+    monkeypatch.setattr(perf, "PERF_MIN_TRADE_COUNT", max(1, PERF_MIN_TRADE_COUNT - 2))
     perf.reset_cache()
 
     tm = TradeManager(starting_balance=1000, hold_period_sec=10, min_hold_bucket="30m-2h")


### PR DESCRIPTION
## Summary
- Import `PERF_FEE_RATIO_THRESHOLD` and `PERF_MIN_TRADE_COUNT` from `config` in performance analytics
- Patch performance threshold constants in tests via `config`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ae9634140c832c8a16aa615be8b2fe