### PR TITLE
feat: make correlation threshold configurable

### DIFF
--- a/config.py
+++ b/config.py
@@ -131,6 +131,10 @@ VERY_HIGH_CONF_BUY_OVERRIDE = float(os.getenv("VERY_HIGH_CONF_BUY_OVERRIDE", "0.
 # Minimum 7-day volatility required for a symbol to be considered.
 MIN_VOLATILITY_7D = float(os.getenv("MIN_VOLATILITY_7D", "0.0001"))
 
+# Maximum allowed price correlation between a candidate and any open position.
+# Symbols exceeding this threshold will be skipped.
+CORRELATION_THRESHOLD = float(os.getenv("CORRELATION_THRESHOLD", "0.8"))
+
 # Minimum 24h trading volume (USD) required for a symbol to be considered.
 # Assets below this threshold are skipped to avoid illiquid markets.
 MIN_24H_VOLUME = float(os.getenv("MIN_24H_VOLUME", "1000000"))

--- a/main.py
+++ b/main.py
@@ -32,6 +32,7 @@ from config import (
     VERY_HIGH_CONF_BUY_OVERRIDE,
     MIN_VOLATILITY_7D,
     HOLDING_PERIOD_SECONDS,
+    CORRELATION_THRESHOLD,
 )
 from exchange_adapter import BinancePaperTradeAdapter
 from threshold_utils import get_dynamic_threshold
@@ -60,8 +61,8 @@ ROTATION_AUDIT_LOG = []  # 📘 In-memory rotation history
 ROTATION_LOG_LIMIT = 10  # How many to keep
 # Protects access to the rotation audit log
 ROTATION_AUDIT_LOCK = threading.Lock()
-# Correlation filter threshold for new candidates
-CORRELATION_THRESHOLD = 0.8
+# Correlation filter threshold for new candidates (imported from config)
+# CORRELATION_THRESHOLD is imported above
 
 # Momentum tier mapping for gating logic
 TIER_RANKS = {"Tier 1": 1, "Tier 2": 2, "Tier 3": 3, "Tier 4": 4}

--- a/tests/test_scan_for_breakouts.py
+++ b/tests/test_scan_for_breakouts.py
@@ -4,6 +4,7 @@ import types
 from unittest.mock import MagicMock
 
 import os
+import config
 import pandas as pd
 import threading
 
@@ -190,6 +191,7 @@ def test_low_volatility_threshold_allows_trade(monkeypatch):
 
 
 def test_scan_for_breakouts_blocks_correlated_entries(monkeypatch):
+    monkeypatch.setattr(config, "CORRELATION_THRESHOLD", 0.8)
     main = _reload_main(monkeypatch)
 
     tm = types.SimpleNamespace(
@@ -237,6 +239,7 @@ def test_scan_for_breakouts_blocks_correlated_entries(monkeypatch):
 
 
 def test_scan_for_breakouts_selects_uncorrelated_candidate(monkeypatch):
+    monkeypatch.setattr(config, "CORRELATION_THRESHOLD", 0.8)
     main = _reload_main(monkeypatch)
 
     tm = types.SimpleNamespace(


### PR DESCRIPTION
## Summary
- add `CORRELATION_THRESHOLD` to `config.py` with env var support
- use the shared config value in `main.py`
- patch correlation threshold via config in tests

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68ae9af8a670832c8f1f35a333ea7734