### PR TITLE
Handle timezone-naive on-chain metrics

### DIFF
--- a/data_fetcher.py
+++ b/data_fetcher.py
@@ -90,7 +90,10 @@ def fetch_onchain_metrics(days=14):
     )
 
     def _default_df(col: str) -> pd.DataFrame:
-        end = pd.Timestamp.utcnow().normalize()
+        # ``pd.Timestamp.utcnow()`` returns a timezone-aware value.  Downstream
+        # code expects naive timestamps, so drop the timezone before building the
+        # placeholder date range.
+        end = pd.Timestamp.utcnow().normalize().tz_localize(None)
         dates = pd.date_range(end - pd.Timedelta(days=days - 1), end, freq="D")
         return pd.DataFrame({"Timestamp": dates, col: [0] * len(dates)})
 

--- a/feature_engineer.py
+++ b/feature_engineer.py
@@ -133,6 +133,9 @@ def add_indicators(df, min_rows: int = MIN_ROWS_AFTER_INDICATORS):
     # which previously resulted in 404 responses.
     onchain = fetch_onchain_metrics()
     if not onchain.empty:
+        # Ensure timestamps are timezone-naive before merging so ``pd.merge_asof``
+        # doesn't complain about mismatched timezone-aware vs. naive data.
+        onchain["Timestamp"] = onchain["Timestamp"].dt.tz_localize(None)
         onchain = onchain.sort_values("Timestamp")
         df = pd.merge_asof(df, onchain, on="Timestamp", direction="backward")
         for col in ["TxVolume", "ActiveAddresses"]:


### PR DESCRIPTION
## Summary
- Drop timezone info when building on-chain placeholder data
- Localize on-chain metric timestamps to naive before merging in feature engineer

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68aea1322430832cbafc91319e8c8c1b