### PR TITLE
Verify 4h aggregates and handle missing features

### DIFF
--- a/tests/test_model_predictor.py
+++ b/tests/test_model_predictor.py
@@ -22,3 +22,27 @@ def test_class_probabilities_logged_at_debug(monkeypatch, caplog):
         model_predictor.predict_signal(df, threshold=0.5)
 
     assert any("Class probabilities" in record.getMessage() for record in caplog.records)
+
+
+def test_predict_signal_fills_missing_4h_features(monkeypatch):
+    class DummyModel:
+        def predict(self, dmatrix):
+            return np.array([[0.1, 0.2, 0.3, 0.15, 0.25]])
+
+    features = [
+        "RSI", "MACD", "Signal", "Hist", "SMA_20", "SMA_50",
+        "Return_1d", "Return_2d", "Return_3d", "Return_5d", "Return_7d",
+        "Price_vs_SMA20", "Price_vs_SMA50", "Volatility_7d", "MACD_Hist_norm",
+        "MACD_4h", "Signal_4h", "Hist_4h", "SMA_4h"
+    ]
+
+    monkeypatch.setattr(model_predictor, "load_model", lambda: (DummyModel(), features))
+    monkeypatch.setattr(model_predictor, "xgb", types.SimpleNamespace(DMatrix=lambda X: X))
+
+    df = pd.DataFrame({f: [1.0] for f in features if not f.endswith("_4h")})
+
+    signal, confidence, cls = model_predictor.predict_signal(df, threshold=0.5)
+    assert signal is not None
+    for col in ["SMA_4h", "MACD_4h", "Signal_4h", "Hist_4h"]:
+        assert col in df.columns
+        assert df[col].iloc[-1] == 0.0


### PR DESCRIPTION
## Summary
- Ensure 4h resample creates SMA/MACD/Signal/Hist columns only when enough history exists and keep placeholders if not
- Preserve optional 4h columns even if NaN and warn about alignment
- Fill missing or NaN 4h features with defaults in model predictor so predictions continue
- Add regression tests for 4h history handling and default feature filling

## Testing
- `PYTHONPATH=. pytest tests/test_feature_engineer.py tests/test_model_predictor.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68aea2ea7b0c832ca196da2c4cba5cd0