### PR TITLE
Improve HTTP error handling and history validation

### DIFF
--- a/feature_engineer.py
+++ b/feature_engineer.py
@@ -28,8 +28,13 @@ def add_indicators(df, min_rows: int = MIN_ROWS_AFTER_INDICATORS):
 
     df["Close"] = pd.to_numeric(df["Close"], errors="coerce")
 
-    if len(df) < 50:
-        logger.warning("⚠️ Not enough candles to compute full indicators: %d rows", len(df))
+    required = max(min_rows, 50)
+    if len(df) < required:
+        logger.warning(
+            "⚠️ Skipping symbol: %d rows (<%d required)",
+            len(df),
+            required,
+        )
         return pd.DataFrame()
 
     # RSI


### PR DESCRIPTION
## Summary
- add explicit 401 and 404 handling with exponential backoff in the generic request wrapper
- validate minimum dataframe length before computing indicators to skip short histories
- test HTTP 401 failures and insufficient historical data scenarios

## Testing
- `PYTHONPATH=. pytest tests/test_safe_request.py tests/test_feature_engineer.py`


------
https://chatgpt.com/codex/tasks/task_e_68aeab0feca0832cacb048b97be38132