### PR TITLE
Fix on-chain metrics chart slugs

### DIFF
--- a/data_fetcher.py
+++ b/data_fetcher.py
@@ -71,8 +71,8 @@ def fetch_onchain_metrics(days=14):
     # to the modern ``blockchain.info`` domain by default. Users may override the
     # base URL via ``BLOCKCHAIN_CHARTS_BASE``.
     base_url = os.getenv("BLOCKCHAIN_CHARTS_BASE", "https://blockchain.info")
-    tx_url = f"{base_url}/charts/transactions"
-    active_url = f"{base_url}/charts/active_addresses"
+    tx_url = f"{base_url}/charts/n-transactions"
+    active_url = f"{base_url}/charts/active-addresses"
     params = {"timespan": f"{days}days", "format": "json"}
 
     # Only retry on server errors for these endpoints

--- a/tests/test_onchain_chart_slugs.py
+++ b/tests/test_onchain_chart_slugs.py
@@ -1,0 +1,28 @@
+import os
+import data_fetcher
+
+def test_fetch_onchain_metrics_uses_new_chart_slugs(monkeypatch, tmp_path):
+    sample_tx = {"values": [{"x": 1722384000, "y": 123}]}
+    sample_active = {"values": [{"x": 1722384000, "y": 456}]}
+    captured = []
+
+    def mock_safe_request(url, params=None, **kwargs):
+        captured.append(url)
+        if "n-transactions" in url:
+            return sample_tx
+        if "active-addresses" in url:
+            return sample_active
+        return None
+
+    monkeypatch.setattr(data_fetcher, "safe_request", mock_safe_request)
+    monkeypatch.setattr(data_fetcher, "CACHE_DIR", tmp_path)
+    os.makedirs(data_fetcher.CACHE_DIR, exist_ok=True)
+
+    df = data_fetcher.fetch_onchain_metrics(days=1)
+
+    assert any("n-transactions" in url for url in captured)
+    assert any("active-addresses" in url for url in captured)
+    assert list(df.columns) == ["Timestamp", "TxVolume", "ActiveAddresses"]
+    assert len(df) == 1
+    assert df["TxVolume"].iloc[0] == 123
+    assert df["ActiveAddresses"].iloc[0] == 456


### PR DESCRIPTION
## Summary
- use correct Blockchain.com chart slugs for transactions and active addresses
- add regression test covering new chart slugs

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68aeb61cf538832c86892232554401b3