### PR TITLE
Make minimum unique samples configurable

### DIFF
--- a/tests/test_prepare_training_data.py
+++ b/tests/test_prepare_training_data.py
@@ -32,7 +32,7 @@ def test_prepare_training_data_augment(monkeypatch):
     monkeypatch.setattr(train_real_model, "add_indicators", lambda d: d)
     monkeypatch.setattr(train_real_model, "load_feature_list", lambda: ["feat"])
 
-    X, y = train_real_model.prepare_training_data("SYM", "coin")
+    X, y = train_real_model.prepare_training_data("SYM", "coin", min_unique_samples=3)
     assert X is not None and y is not None
     counts = y.value_counts().to_dict()
     assert counts[0] == 20
@@ -54,6 +54,24 @@ def test_prepare_training_data_drops_on_few_unique(monkeypatch, caplog):
     monkeypatch.setattr(train_real_model, "load_feature_list", lambda: ["feat"])
 
     with caplog.at_level("WARNING", logger=train_real_model.logger.name):
-        X, y = train_real_model.prepare_training_data("SYM", "coin")
+        X, y = train_real_model.prepare_training_data("SYM", "coin", min_unique_samples=5)
     assert X is None and y is None
     assert any("unique rows" in r.getMessage() for r in caplog.records)
+
+
+def test_prepare_training_data_passes_when_threshold_lowered(monkeypatch):
+    returns = (
+        [-0.05] * 10
+        + [-0.02] * 10
+        + [0.01] * 10
+        + [0.02] * 10
+        + [0.05] * 10
+    )
+    features_first = [0, 1, 2, 3, 0, 1, 2, 3, 0, 1] + list(range(10, 50))
+    df = _make_df(returns, features_first)
+    monkeypatch.setattr(train_real_model, "fetch_ohlcv_smart", lambda *a, **k: df)
+    monkeypatch.setattr(train_real_model, "add_indicators", lambda d: d)
+    monkeypatch.setattr(train_real_model, "load_feature_list", lambda: ["feat"])
+
+    X, y = train_real_model.prepare_training_data("SYM", "coin", min_unique_samples=3)
+    assert X is not None and y is not None


### PR DESCRIPTION
## Summary
- allow `prepare_training_data` to accept `min_unique_samples` and use it instead of hard-coded 5
- expose `--min-unique-samples` CLI flag for training script
- expand tests to cover variable unique sample thresholds

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68aeb620a610832c967b5f5a45badabb