### PR TITLE
Handle non-JSON on-chain metrics responses

### DIFF
--- a/tests/test_onchain_content_type_failures.py
+++ b/tests/test_onchain_content_type_failures.py
@@ -1,0 +1,64 @@
+import os
+import json
+
+import data_fetcher
+
+def _setup_cache(monkeypatch, tmp_path):
+    monkeypatch.setattr(data_fetcher, "CACHE_DIR", tmp_path)
+    os.makedirs(data_fetcher.CACHE_DIR, exist_ok=True)
+
+
+def test_fetch_onchain_metrics_html_response(monkeypatch, tmp_path, caplog):
+    calls = []
+
+    def fake_safe_request(url, params=None, retry_statuses=None, backoff_on_429=False, headers=None):
+        calls.append(url)
+        if "api.blockchain.info" in url:
+            return {"values": [{"x": 1722384000, "y": 1}]}
+        return None
+
+    class HTMLResp:
+        status_code = 200
+        headers = {"content-type": "text/html"}
+        text = "<html>oops</html>"
+        def json(self):
+            raise ValueError("no json")
+
+    monkeypatch.setattr(data_fetcher, "safe_request", fake_safe_request)
+    monkeypatch.setattr(data_fetcher.requests, "get", lambda *a, **k: HTMLResp())
+    _setup_cache(monkeypatch, tmp_path)
+
+    with caplog.at_level("ERROR"):
+        df = data_fetcher.fetch_onchain_metrics(days=1)
+
+    assert not df.empty
+    assert "Non-JSON response" in caplog.text
+    assert any("api.blockchain.info" in c for c in calls)
+
+
+def test_fetch_onchain_metrics_invalid_json(monkeypatch, tmp_path, caplog):
+    calls = []
+
+    def fake_safe_request(url, params=None, retry_statuses=None, backoff_on_429=False, headers=None):
+        calls.append(url)
+        if "api.blockchain.info" in url:
+            return {"values": [{"x": 1722384000, "y": 2}]}
+        return None
+
+    class BadJSONResp:
+        status_code = 200
+        headers = {"content-type": "application/json"}
+        text = "bad"
+        def json(self):
+            raise json.JSONDecodeError("Expecting value", "", 0)
+
+    monkeypatch.setattr(data_fetcher, "safe_request", fake_safe_request)
+    monkeypatch.setattr(data_fetcher.requests, "get", lambda *a, **k: BadJSONResp())
+    _setup_cache(monkeypatch, tmp_path)
+
+    with caplog.at_level("ERROR"):
+        df = data_fetcher.fetch_onchain_metrics(days=1)
+
+    assert not df.empty
+    assert "JSON decode error" in caplog.text
+    assert any("api.blockchain.info" in c for c in calls)

--- a/tests/test_onchain_placeholder_cache.py
+++ b/tests/test_onchain_placeholder_cache.py
@@ -20,7 +20,8 @@ def test_fetch_onchain_metrics_caches_fallback_df(monkeypatch, tmp_path):
     assert not df1.empty and not df2.empty
     assert (df1["TxVolume"] == 0).all()
     assert (df1["ActiveAddresses"] == 0).all()
-    assert calls["count"] == 2
+    # Two endpoints plus a legacy-domain retry for each
+    assert calls["count"] == 4
 
 
 def test_fetch_onchain_metrics_returns_data(monkeypatch, tmp_path):


### PR DESCRIPTION
## Summary
- validate on-chain metrics responses for JSON content and log details
- retry using legacy blockchain.info endpoint when non-JSON data is returned
- test HTML and malformed JSON response handling

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68aebdbe8fb4832c99f2f462cfa8df54