### PR TITLE
Use updated Blockchain.com charts endpoints

### DIFF
--- a/tests/test_onchain_chart_slugs.py
+++ b/tests/test_onchain_chart_slugs.py
@@ -7,7 +7,7 @@ def test_fetch_onchain_metrics_uses_new_chart_slugs(monkeypatch, tmp_path):
     captured = []
 
     def mock_safe_request(url, params=None, **kwargs):
-        captured.append(url)
+        captured.append((url, params))
         if "n-transactions" in url:
             return sample_tx
         if "active-addresses" in url:
@@ -20,8 +20,10 @@ def test_fetch_onchain_metrics_uses_new_chart_slugs(monkeypatch, tmp_path):
 
     df = data_fetcher.fetch_onchain_metrics(days=1)
 
-    assert any("n-transactions" in url for url in captured)
-    assert any("active-addresses" in url for url in captured)
+    assert any("n-transactions" in url for url, _ in captured)
+    assert any("active-addresses" in url for url, _ in captured)
+    assert all(params.get("format") == "json" for _, params in captured)
+    assert any("api.blockchain.com" in url for url, _ in captured)
     assert list(df.columns) == ["Timestamp", "TxVolume", "ActiveAddresses"]
     assert len(df) == 1
     assert df["TxVolume"].iloc[0] == 123

--- a/tests/test_onchain_content_type_failures.py
+++ b/tests/test_onchain_content_type_failures.py
@@ -28,11 +28,12 @@ def test_fetch_onchain_metrics_html_response(monkeypatch, tmp_path, caplog):
     monkeypatch.setattr(data_fetcher.requests, "get", lambda *a, **k: HTMLResp())
     _setup_cache(monkeypatch, tmp_path)
 
-    with caplog.at_level("ERROR"):
+    with caplog.at_level("WARNING"):
         df = data_fetcher.fetch_onchain_metrics(days=1)
 
     assert not df.empty
     assert "Non-JSON response" in caplog.text
+    assert any("api.blockchain.com" in c for c in calls)
     assert any("api.blockchain.info" in c for c in calls)
 
 
@@ -56,9 +57,10 @@ def test_fetch_onchain_metrics_invalid_json(monkeypatch, tmp_path, caplog):
     monkeypatch.setattr(data_fetcher.requests, "get", lambda *a, **k: BadJSONResp())
     _setup_cache(monkeypatch, tmp_path)
 
-    with caplog.at_level("ERROR"):
+    with caplog.at_level("WARNING"):
         df = data_fetcher.fetch_onchain_metrics(days=1)
 
     assert not df.empty
     assert "JSON decode error" in caplog.text
+    assert any("api.blockchain.com" in c for c in calls)
     assert any("api.blockchain.info" in c for c in calls)


### PR DESCRIPTION
## Summary
- default to the modern `api.blockchain.com` charts domain
- parse both legacy and new chart response formats and log HTML/invalid JSON as warnings
- tests verify format=json params, new domain usage and downgraded log levels

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68aec230eea8832ca27d796dbb6a7075