### PR TITLE
docs: clarify dependency install before training

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,11 @@ This repository contains utilities for analyzing cryptocurrency markets and auto
 
 To enable machine-learning based predictions you can train an XGBoost model:
 
-1. Ensure TA-Lib and the required Python packages (e.g., `xgboost`, `pandas`) are installed.
+1. Install the Python dependencies:
+   ```bash
+   pip install -r requirements.txt
+   ```
+   Ensure the TA-Lib library is installed before running this command.
 2. Run the training script:
    ```bash
    python train_real_model.py

--- a/train_real_model.py
+++ b/train_real_model.py
@@ -3,6 +3,7 @@
 import os
 import json
 import argparse
+import sys
 from typing import Optional
 
 import numpy as np
@@ -420,6 +421,13 @@ def main():
         help="Minimum unique rows required per class before resampling",
     )
     args = parser.parse_args()
+
+    if args.oversampler in {"smote", "adasyn"} and SMOTE is None:
+        logger.error(
+            "imbalanced-learn is required for %s oversampling. Run 'pip install -r requirements.txt' to install it.",
+            args.oversampler,
+        )
+        sys.exit(1)
 
     coins = [
         ("btc", "bitcoin"),


### PR DESCRIPTION
## Summary
- Document running `pip install -r requirements.txt` before training
- Exit training if oversampling requested but `imbalanced-learn` is missing

## Testing
- `pytest -q > /tmp/pytest.log && tail -n 20 /tmp/pytest.log`


------
https://chatgpt.com/codex/tasks/task_e_68aec95003a4832cabbc0301e19f2de4