### PR TITLE
Ensure on-chain metrics use JSON API and fallback

### DIFF
--- a/tests/test_data_fetcher_warnings.py
+++ b/tests/test_data_fetcher_warnings.py
@@ -22,7 +22,7 @@ def test_no_future_warning_on_timestamp_parsing(monkeypatch, tmp_path):
     def mock_safe_request(url, params=None, **kwargs):
         if "fng" in url:
             return fg_sample
-        if "transactions-per-day" in url:
+        if "n-transactions" in url:
             return tx_sample
         if "active-addresses" in url:
             return active_sample

--- a/tests/test_onchain_chart_slugs.py
+++ b/tests/test_onchain_chart_slugs.py
@@ -22,8 +22,11 @@ def test_fetch_onchain_metrics_uses_new_chart_slugs(monkeypatch, tmp_path):
 
     assert any("n-transactions" in url for url, _ in captured)
     assert any("active-addresses" in url for url, _ in captured)
-    assert all(params.get("format") == "json" for _, params in captured)
-    assert any("blockchain.info/charts" in url for url, _ in captured)
+    assert all(
+        params.get("format") == "json" and params.get("cors") == "true"
+        for _, params in captured
+    )
+    assert any("api.blockchain.info/charts" in url for url, _ in captured)
     assert list(df.columns) == ["Timestamp", "TxVolume", "ActiveAddresses"]
     assert len(df) == 1
     assert df["TxVolume"].iloc[0] == 123


### PR DESCRIPTION
## Summary
- query Blockchain.com charts API via api.blockchain.info with `format=json&cors=true`
- log non-JSON on-chain responses once and fall back to deterministic placeholder DataFrames
- test HTML vs JSON responses and verify new `cors` parameter and endpoint

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68aecc7a61b8832cab278fa673e4a630