### PR TITLE
Log human-readable class names and validate counts in training

### DIFF
--- a/train_real_model.py
+++ b/train_real_model.py
@@ -203,11 +203,20 @@ def prepare_training_data(
 
 def train_model(X, y, oversampler: Optional[str] = None):
     logger.info("\n🚀 Training multi-class classifier...")
+    original_label_names = {
+        0: "big_loss",
+        1: "small_loss",
+        2: "neutral",
+        3: "small_gain",
+        4: "big_gain",
+    }
 
     le = LabelEncoder()
     y_encoded = le.fit_transform(y)
     class_count = len(le.classes_)
-    logger.info("✅ Model will use %d classes: %s", class_count, list(le.classes_))
+    label_names = [original_label_names[cls] for cls in le.classes_]
+    assert class_count == len(label_names), "Encoded class count mismatch"
+    logger.info("✅ Model will use %d classes: %s", class_count, label_names)
 
     logger.info("📊 Original class distribution:")
     class_dist = pd.Series(y_encoded).value_counts().sort_index()
@@ -222,16 +231,11 @@ def train_model(X, y, oversampler: Optional[str] = None):
         le = LabelEncoder()
         y_encoded = le.fit_transform(y)
         class_count = len(le.classes_)
-        logger.info("✅ Using %d classes after drop: %s", class_count, list(le.classes_))
+        label_names = [original_label_names[cls] for cls in le.classes_]
+        assert class_count == len(label_names), "Encoded class count mismatch"
+        logger.info("✅ Using %d classes after drop: %s", class_count, label_names)
         class_dist = pd.Series(y_encoded).value_counts().sort_index()
 
-    original_label_names = {
-        0: "big_loss",
-        1: "small_loss",
-        2: "neutral",
-        3: "small_gain",
-        4: "big_gain",
-    }
     label_map = {i: original_label_names[cls] for i, cls in enumerate(le.classes_)}
 
     # === Time-based train/test split (chronological) ===


### PR DESCRIPTION
## Summary
- Log class names using human-readable labels instead of raw label codes
- Add assertions ensuring encoded class count matches the names list

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68aecf2da914832cabe377924164eb89