### PR TITLE
Fix per-class recall mapping in training metrics summary

### DIFF
--- a/train_real_model.py
+++ b/train_real_model.py
@@ -496,8 +496,8 @@ def train_model(X, y, oversampler: Optional[str] = None):
     metrics_summary = {
         "macro_f1": report_dict["macro avg"]["f1-score"],
         "per_class_recall": {
-            name: report_dict[str(lbl)]["recall"]
-            for name, lbl in zip(target_names, labels_sorted)
+            name: report_dict.get(name, {}).get("recall", 0.0)
+            for name in target_names
         },
     }
 


### PR DESCRIPTION
## Summary
- Fix metrics summary to lookup per-class recall by target name instead of numeric label strings, avoiding `KeyError`

## Testing
- `pytest`
- `python - <<'PY' ... train_real_model.train_model(...) ... PY`

------
https://chatgpt.com/codex/tasks/task_e_68aed2b2dd70832c925373eb90fec5b5