### PR TITLE
Add fallback exchange fetch for sparse training data

### DIFF
--- a/tests/test_prepare_training_data.py
+++ b/tests/test_prepare_training_data.py
@@ -31,6 +31,16 @@ def test_prepare_training_data_augment(monkeypatch):
     monkeypatch.setattr(train_real_model, "fetch_ohlcv_smart", lambda *a, **k: df)
     monkeypatch.setattr(train_real_model, "add_indicators", lambda d: d)
     monkeypatch.setattr(train_real_model, "load_feature_list", lambda: ["feat"])
+    monkeypatch.setattr(
+        train_real_model.data_fetcher,
+        "fetch_binance_us_ohlcv",
+        lambda *a, **k: pd.DataFrame(),
+    )
+    monkeypatch.setattr(
+        train_real_model.data_fetcher,
+        "fetch_dexscreener_ohlcv",
+        lambda *a, **k: pd.DataFrame(),
+    )
 
     X, y = train_real_model.prepare_training_data("SYM", "coin", min_unique_samples=3)
     assert X is not None and y is not None


### PR DESCRIPTION
## Summary
- Retry Binance.US then DexScreener with extended limits when a class lacks unique rows before discarding a coin
- Replace dropped coins using next dynamic gainer and log replacement path during training
- Stub alternate exchange fetches in tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68afda109390832c9efb3a8ee0f57699