### PR TITLE
Prioritize Binance for OHLCV data

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,20 @@ source code by setting environment variables:
 
 These options allow fine-tuning of momentum evaluation without code changes.
 
+### OHLCV Data Source Fallback
+
+Candlestick data is pulled from several providers in order of preference:
+
+1. **Coinbase** – primary source
+2. **Binance.US**
+3. **Binance**
+4. **Yahoo Finance**
+5. **CoinGecko**
+6. **DexScreener**
+
+If Coinbase returns fewer than 60 rows for a request, the Binance sources are
+moved to the front of the list so they are tried first on subsequent attempts.
+
 ### Tuning Trade Aggressiveness
 
 Several environment variables control how aggressively the bot enters trades.


### PR DESCRIPTION
## Summary
- add Binance.US and Binance to OHLCV source order
- retry from Binance first when Coinbase returns less than 60 rows
- document the OHLCV fallback sequence for contributors

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68afda079160832cb523c503f463123e