### PR TITLE
Use dynamic return thresholds

### DIFF
--- a/tests/test_prepare_training_data.py
+++ b/tests/test_prepare_training_data.py
@@ -35,8 +35,8 @@ def test_prepare_training_data_augment(monkeypatch):
     X, y = train_real_model.prepare_training_data("SYM", "coin", min_unique_samples=3)
     assert X is not None and y is not None
     counts = y.value_counts().to_dict()
-    assert counts[0] == 20
-    assert counts[4] == 50
+    assert counts[0] == 28
+    assert counts[4] == 32
 
 
 def test_prepare_training_data_drops_on_few_unique(monkeypatch, caplog):

--- a/threshold_utils.py
+++ b/threshold_utils.py
@@ -1,7 +1,54 @@
-def get_dynamic_threshold(volatility_7d, base=0.65):
+"""Utility helpers for dynamic threshold calculations.
+
+This module centralises logic for determining various thresholds used
+throughout the project.  Historically only :func:`get_dynamic_threshold`
+was provided, but more advanced return bucketing now requires dynamic
+cutoffs derived from each asset's historical behaviour.
+"""
+
+from __future__ import annotations
+
+from typing import Iterable, Dict
+
+import numpy as np
+
+
+def get_dynamic_threshold(volatility_7d: float, base: float = 0.65) -> float:
     """Adjust the confidence threshold based on 7d volatility."""
     if volatility_7d > 0.10:
         return base - 0.05
     if volatility_7d < 0.03:
         return base + 0.05
     return base
+
+
+def compute_return_thresholds(
+    series: Iterable[float],
+    quantiles: Iterable[float] = (0.2, 0.4, 0.6, 0.8),
+) -> Dict[str, float]:
+    """Compute percentile-based return thresholds.
+
+    Parameters
+    ----------
+    series:
+        Sequence of historical return values.
+    quantiles:
+        Percentiles used to determine the bucket boundaries. The default
+        (20th, 40th, 60th and 80th) yields five buckets with dynamic cutoffs.
+
+    Returns
+    -------
+    dict
+        Mapping with keys ``"big_loss"``, ``"loss"``, ``"gain"`` and
+        ``"big_gain"`` representing the four boundary points used by
+        :func:`train_real_model.return_bucket`.
+    """
+
+    q = np.quantile(list(series), quantiles)
+    return {
+        "big_loss": float(q[0]),
+        "loss": float(q[1]),
+        "gain": float(q[2]),
+        "big_gain": float(q[3]),
+    }
+


### PR DESCRIPTION
## Summary
- add `compute_return_thresholds` for percentile-based return bucketing
- bucket training targets with per-symbol thresholds and dynamic oversampling
- update tests for new data prep and adaptive stagnation handling

## Testing
- `PYTHONPATH=. pytest`

------
https://chatgpt.com/codex/tasks/task_e_68afda0bfd0c832c9eb70bce0a71564f