### PR TITLE
Ensure GridSearchCV uses single worker/thread on Windows

### DIFF
--- a/train_real_model.py
+++ b/train_real_model.py
@@ -500,17 +500,19 @@ def train_model(X, y, oversampler: Optional[str] = None):
         "subsample": [0.8, 1.0],
         "colsample_bytree": [0.8, 1.0],
     }
+    # Use a single worker process and single-threaded fits for Windows stability
     grid = GridSearchCV(
         XGBClassifier(
             objective="multi:softprob",
             num_class=len(le.classes_),
             random_state=42,
             eval_metric="mlogloss",
+            n_jobs=1,  # use a single thread per fit for Windows stability (nthread for older versions)
         ),
         param_grid,
         scoring="f1_macro",
         cv=TimeSeriesSplit(n_splits=n_splits),
-        n_jobs=-1,
+        n_jobs=1,  # single process to avoid Windows multiprocessing issues
         refit=True,
     )
     grid.fit(X_train_bal, y_train_bal, sample_weight=sample_weights)


### PR DESCRIPTION
## Summary
- Use single worker process for GridSearchCV to avoid Windows multiprocessing issues
- Configure XGBClassifier to run single-threaded for stability on Windows

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68afe83be0e0832c94e385df5d428150