### PR TITLE
Pin xgboost version and reinstall deps on update

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,12 @@ This repository contains utilities for analyzing cryptocurrency markets and auto
    ```bash
    pip install -r requirements.txt
    ```
+   If the repository is updated later, reinstall dependencies to ensure pinned
+   versions are used:
+   ```bash
+   pip install --upgrade -r requirements.txt
+   ```
+   The `update_repo.bat` script performs this step automatically.
 
 ## Training the Model
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,5 +7,5 @@ numpy
 joblib
 ta
 TA-Lib
-xgboost  # Required for loading the ML model
+xgboost==1.7.6  # Required for loading the ML model
 imbalanced-learn>=0.11

--- a/update_repo.bat
+++ b/update_repo.bat
@@ -14,6 +14,13 @@ if %errorlevel% neq 0 (
     goto end
 )
 
+echo Installing dependencies...
+pip install --upgrade -r requirements.txt
+if %errorlevel% neq 0 (
+    echo Failed to install dependencies.
+    goto end
+)
+
 echo Update of main branch complete.
 :end
 pause


### PR DESCRIPTION
## Summary
- pin xgboost dependency to version 1.7.6
- reinstall requirements after repository updates
- document the need to reinstall dependencies when updating

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68afe83d3958832c9d4848d77773b7a2