### PR TITLE
Add SMOTE oversampling training test

### DIFF
--- a/tests/test_train_model_oversampling.py
+++ b/tests/test_train_model_oversampling.py
@@ -1,0 +1,25 @@
+import os
+import sys
+import pandas as pd
+import numpy as np
+
+# Ensure repository root on path for imports
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+from train_real_model import train_model
+
+
+def test_train_model_runs_with_smote():
+    # Create deterministic synthetic dataset with 5 classes
+    n_classes = 5
+    samples_per_class = 10  # ensures sufficient samples for SMOTE
+    y = pd.Series(np.tile(np.arange(n_classes), samples_per_class))
+    X = pd.DataFrame({
+        "feat1": np.arange(len(y)),
+        "feat2": np.arange(len(y)) * 2,
+    })
+
+    model, labels = train_model(X, y, oversampler="smote")
+
+    # Model should be returned and all classes should be preserved
+    assert model is not None
+    assert set(labels) == set(range(n_classes))


### PR DESCRIPTION
## Summary
- add unit test that builds a small 5-class dataset and trains `train_model` with SMOTE oversampling

## Testing
- `pytest tests/test_train_model_oversampling.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68afea030e78832cad6ab4082ce3768e