### PR TITLE
Use Blockchain.info chart API and add endpoint tests

### DIFF
--- a/data_fetcher.py
+++ b/data_fetcher.py
@@ -71,12 +71,12 @@ def fetch_onchain_metrics(days=14):
     # Blockchain.com exposes public chart endpoints for several Bitcoin
     # on-chain statistics. Each response has a ``values`` array of
     # ``{"x": timestamp, "y": value}`` entries. ``days`` controls how much
-    # history to request. The legacy ``api.blockchain.info`` domain has been
-    # deprecated in favour of ``api.blockchain.com``. Users may override the base
-    # URL via ``BLOCKCHAIN_CHARTS_BASE``. Requests always pass ``format=json`` to
-    # ensure a JSON payload is returned.
+    # history to request. As of today the charts API is served from the legacy
+    # ``api.blockchain.info`` domain. If a new path is introduced, callers may
+    # override the base URL via ``BLOCKCHAIN_CHARTS_BASE``. Requests always pass
+    # ``format=json`` to ensure a JSON payload is returned.
     base_url = os.getenv(
-        "BLOCKCHAIN_CHARTS_BASE", "https://api.blockchain.com/charts"
+        "BLOCKCHAIN_CHARTS_BASE", "https://api.blockchain.info/charts"
     )
     tx_url = f"{base_url}/n-transactions"
     active_url = f"{base_url}/active-addresses"

--- a/tests/test_blockchain_chart_endpoints.py
+++ b/tests/test_blockchain_chart_endpoints.py
@@ -1,0 +1,27 @@
+import os
+import requests
+
+BASE = os.getenv("BLOCKCHAIN_CHARTS_BASE", "https://api.blockchain.info/charts")
+PARAMS = {"timespan": "5days", "format": "json", "cors": "true"}
+
+
+def _get_chart(slug: str):
+    url = f"{BASE}/{slug}"
+    resp = requests.get(url, params=PARAMS, timeout=10)
+    assert resp.status_code == 200
+    data = resp.json()
+    assert isinstance(data, dict)
+    assert "values" in data and isinstance(data["values"], list)
+    if data["values"]:
+        first = data["values"][0]
+        assert isinstance(first, dict)
+        assert "x" in first and "y" in first
+    return data
+
+
+def test_transactions_chart_endpoint():
+    _get_chart("n-transactions")
+
+
+def test_active_addresses_chart_endpoint():
+    _get_chart("active-addresses")

--- a/tests/test_onchain_chart_slugs.py
+++ b/tests/test_onchain_chart_slugs.py
@@ -23,10 +23,12 @@ def test_fetch_onchain_metrics_uses_new_chart_slugs(monkeypatch, tmp_path):
     assert any("n-transactions" in url for url, _ in captured)
     assert any("active-addresses" in url for url, _ in captured)
     assert all(
-        params.get("format") == "json" and params.get("cors") == "true"
+        params.get("format") == "json"
+        and params.get("cors") == "true"
+        and params.get("timespan") == "1days"
         for _, params in captured
     )
-    assert any("api.blockchain.com/charts" in url for url, _ in captured)
+    assert any("api.blockchain.info/charts" in url for url, _ in captured)
     assert list(df.columns) == ["Timestamp", "TxVolume", "ActiveAddresses"]
     assert len(df) == 1
     assert df["TxVolume"].iloc[0] == 123

--- a/tests/test_onchain_content_type_failures.py
+++ b/tests/test_onchain_content_type_failures.py
@@ -37,8 +37,11 @@ def test_fetch_onchain_metrics_html_response(monkeypatch, tmp_path, caplog):
     assert not df.empty
     assert "Non-JSON response" in caplog.text
     assert len(calls) == 2
-    assert all("api.blockchain.com/charts" in url for url, _ in calls)
-    assert all(p.get("cors") == "true" and p.get("format") == "json" for _, p in calls)
+    assert all("api.blockchain.info/charts" in url for url, _ in calls)
+    assert all(
+        p.get("cors") == "true" and p.get("format") == "json" and p.get("timespan") == "1days"
+        for _, p in calls
+    )
 
 
 def test_fetch_onchain_metrics_invalid_json(monkeypatch, tmp_path, caplog):
@@ -68,5 +71,8 @@ def test_fetch_onchain_metrics_invalid_json(monkeypatch, tmp_path, caplog):
     assert not df.empty
     assert "JSON decode error" in caplog.text
     assert len(calls) == 2
-    assert all("api.blockchain.com/charts" in url for url, _ in calls)
-    assert all(p.get("cors") == "true" and p.get("format") == "json" for _, p in calls)
+    assert all("api.blockchain.info/charts" in url for url, _ in calls)
+    assert all(
+        p.get("cors") == "true" and p.get("format") == "json" and p.get("timespan") == "1days"
+        for _, p in calls
+    )


### PR DESCRIPTION
## Summary
- switch on-chain metric base URL to legacy `api.blockchain.info` charts API
- tighten tests to check `timespan`/`format` parameters and new base URL
- add integration tests confirming `n-transactions` and `active-addresses` endpoints respond with JSON

## Testing
- `pytest -q` *(fails: ProxyError when reaching `api.blockchain.info`)*

------
https://chatgpt.com/codex/tasks/task_e_68b06d8eaa60832ca8b7503aa6185a4e