### PR TITLE
Expand OHLCV history for breakout scans

### DIFF
--- a/data_fetcher.py
+++ b/data_fetcher.py
@@ -721,7 +721,9 @@ async def fetch_ohlcv_smart_async(symbol, **kwargs):
 
 def fetch_binance_ohlcv(symbol, interval="15m", limit=96, **kwargs):
     ttl = kwargs.get("ttl", OHLCV_TTL)
-    cache_limit = kwargs.get("cache_limit", kwargs.get("limit", OHLCV_CACHE_LIMIT))
+    cache_limit = kwargs.get(
+        "cache_limit", kwargs.get("limit") or OHLCV_CACHE_LIMIT
+    )
     cached, age = load_ohlcv_cache(symbol, interval)
     if cached is not None and age is not None and age < ttl:
         logger.info(f"📦 Using cached Binance OHLCV for {symbol}")
@@ -774,7 +776,9 @@ def fetch_binance_ohlcv(symbol, interval="15m", limit=96, **kwargs):
 
 def fetch_binance_us_ohlcv(symbol, interval="15m", limit=96, **kwargs):
     ttl = kwargs.get("ttl", OHLCV_TTL)
-    cache_limit = kwargs.get("cache_limit", kwargs.get("limit", OHLCV_CACHE_LIMIT))
+    cache_limit = kwargs.get(
+        "cache_limit", kwargs.get("limit") or OHLCV_CACHE_LIMIT
+    )
     cached, age = load_ohlcv_cache(symbol, interval)
     if cached is not None and age is not None and age < ttl:
         logger.info(f"📦 Using cached Binance.US OHLCV for {symbol}")
@@ -821,8 +825,10 @@ def fetch_coinbase_ohlcv(symbol, interval="15m", days=1, limit=300, **kwargs):
     """Fetch OHLCV data from Coinbase with caching and incremental updates."""
 
     ttl = kwargs.get("ttl", OHLCV_TTL)
-    cache_limit = kwargs.get("cache_limit", kwargs.get("limit", OHLCV_CACHE_LIMIT))
-    chunk_limit = min(limit, 300)
+    cache_limit = kwargs.get(
+        "cache_limit", kwargs.get("limit") or OHLCV_CACHE_LIMIT
+    )
+    chunk_limit = min(limit or 300, 300)
     cached, age = load_ohlcv_cache(symbol, interval)
     if cached is not None and not cached.empty:
         # Normalize cached timestamps to UTC so subsequent comparisons work

--- a/main.py
+++ b/main.py
@@ -184,7 +184,7 @@ def scan_for_breakouts():
 
     logger.info("📡 Fetching OHLCV data for candidates...")
     ohlcvs = [
-        fetch_ohlcv_smart(symbol, coin_id=coin_id, days=10, limit=200)
+        fetch_ohlcv_smart(symbol, coin_id=coin_id, days=10, limit=500)
         for coin_id, symbol, _ in fetch_meta
     ] if fetch_meta else []
 


### PR DESCRIPTION
## Summary
- Request more historical data in `scan_for_breakouts`, fetching 500 OHLCV rows per candidate.
- Ensure Binance, Binance.US, and Coinbase OHLCV fetchers preserve extended histories by defaulting cache limits when no explicit limit is provided.

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b06d8b7b7c832cb6790e1def75523e