### PR TITLE
Handle XGBoost models correctly during calibration

### DIFF
--- a/analytics/calibration_utils.py
+++ b/analytics/calibration_utils.py
@@ -6,6 +6,7 @@ import numpy as np
 import pandas as pd
 from sklearn.calibration import CalibratedClassifierCV
 from sklearn.metrics import precision_recall_curve, roc_curve
+from sklearn.base import is_classifier
 
 
 def calibrate_and_analyze(model, X_val, y_val, label_names) -> Tuple[CalibratedClassifierCV, Dict[str, float]]:
@@ -46,6 +47,9 @@ def calibrate_and_analyze(model, X_val, y_val, label_names) -> Tuple[CalibratedC
             f"{len(raw_probas)} != labels length {len(y_val)}",
         )
         return model, {}
+
+    if not is_classifier(model) and hasattr(model, "predict_proba"):
+        setattr(model, "_estimator_type", "classifier")
 
     calibrator = CalibratedClassifierCV(model, cv="prefit", method="isotonic")
     calibrator.fit(X_val, y_val)


### PR DESCRIPTION
## Summary
- Ensure calibration step treats mis-labeled estimators (e.g., XGBClassifier) as classifiers
- Import `is_classifier` and set `_estimator_type` before constructing `CalibratedClassifierCV`

## Testing
- `pytest` *(fails: ProxyError: HTTPSConnectionPool(host='api.blockchain.com', port=443): Max retries exceeded with url: /charts/n-transactions)*

------
https://chatgpt.com/codex/tasks/task_e_68b0704f9954832c9e5908bd7c7bd4e5