### PR TITLE
Persist trained feature list in features.json

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,8 @@ To enable machine-learning based predictions you can train an XGBoost model:
    ```bash
    python train_real_model.py
    ```
-It writes the trained model to `ml_model.json` and the expected feature list to `features.json`.
+It writes the trained model to `ml_model.json` and overwrites `features.json` with the exact
+feature names used, keeping inference and training in sync.
 3. The bot loads these files at runtime in [`model_predictor.py`](model_predictor.py).
 
 ### Handling Class Imbalance

--- a/train_real_model.py
+++ b/train_real_model.py
@@ -597,7 +597,12 @@ def train_model(X, y, oversampler: Optional[str] = None, fast: bool = False):
     return model, le.classes_
 
 def main():
-    parser = argparse.ArgumentParser(description="Train crypto classifier")
+    parser = argparse.ArgumentParser(
+        description=(
+            "Train crypto classifier and overwrite features.json with the "
+            "feature names used during training"
+        )
+    )
     parser.add_argument(
         "--oversampler",
         choices=["smote", "adasyn", "borderline"],
@@ -689,9 +694,10 @@ def main():
         oversampler=args.oversampler,
         fast=args.fast,
     )
-    model.save_model("ml_model.json")
+    feature_list = X_all.columns.tolist()
     with open("features.json", "w") as f:
-        json.dump(X_all.columns.tolist(), f)
+        json.dump(feature_list, f, indent=2)
+    model.save_model("ml_model.json")
     with open("labels.json", "w") as f:
         json.dump([int(lbl) for lbl in labels], f)
     logger.info("💾 Saved multi-class model, feature list, and labels")


### PR DESCRIPTION
## Summary
- Save the exact feature column names used for training into `features.json`
- Update CLI help to mention `features.json` is overwritten with training features
- Clarify in README that training replaces `features.json` with the model's features

## Testing
- `pytest` *(fails: ProxyError: HTTPSConnectionPool(host='api.blockchain.info', port=443))*

------
https://chatgpt.com/codex/tasks/task_e_68b071a8a4cc832c9bc47f60db9ab3a3