### PR TITLE
feat: add atr-based stop buffer

### DIFF
--- a/config.py
+++ b/config.py
@@ -58,6 +58,14 @@ ERROR_DELAY = float(os.getenv("ERROR_DELAY", "0"))
 ATR_MULT_SL = float(os.getenv("ATR_MULT_SL", "2.0"))
 ATR_MULT_TP = float(os.getenv("ATR_MULT_TP", "3.0"))
 
+# Additional buffer applied beyond the stop-loss based on ATR or volatility.
+# Provides flexibility for wider stops on more volatile assets.
+SL_BUFFER_ATR_MULT = float(os.getenv("SL_BUFFER_ATR_MULT", "0.2"))
+
+# Factor to reduce the stop-loss buffer once break-even is reached.
+# Values below 1.0 tighten the stop to lock in profits.
+BREAKEVEN_BUFFER_MULT = float(os.getenv("BREAKEVEN_BUFFER_MULT", "0.5"))
+
 # === Risk management and trade sizing ===
 # Percentage of account equity risked per trade (e.g. 0.01 = 1%)
 RISK_PER_TRADE = float(os.getenv("RISK_PER_TRADE", "0.02"))

--- a/tests/test_trade_manager.py
+++ b/tests/test_trade_manager.py
@@ -240,6 +240,7 @@ def test_hold_period_delays_exits(monkeypatch):
     tm.risk_per_trade = 1.0
     tm.slippage_pct = 0.0
     tm.trade_fee_pct = 0.0
+    tm.sl_buffer_atr_mult = 0.0
     df = mock_indicator_df()
     monkeypatch.setattr('data_fetcher.fetch_ohlcv_smart', lambda *a, **k: df)
     monkeypatch.setattr('feature_engineer.add_indicators', lambda d: d)


### PR DESCRIPTION
## Summary
- replace fixed stop-loss buffer with ATR/volatility-based buffer
- allow optional tightening after breakeven
- adjust tests for new stop-loss buffer

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b5aa64bd44832cbcd63047cf7080c7