### PR TITLE
Track per-symbol PnL and filter unprofitable symbols

### DIFF
--- a/config.py
+++ b/config.py
@@ -85,6 +85,12 @@ MAX_DAILY_LOSS_PCT = float(os.getenv("MAX_DAILY_LOSS_PCT", "0.05"))
 # before executing any position.
 MIN_PROFIT_FEE_RATIO = float(os.getenv("MIN_PROFIT_FEE_RATIO", "7.0"))
 
+# Minimum cumulative PnL (in USD) required for a symbol to remain tradable.
+# Symbols with cumulative PnL below this threshold will be skipped unless
+# ``SYMBOL_PNL_THRESHOLD`` is unset, in which case the filter is disabled.
+_sym_pnl_thresh = os.getenv("SYMBOL_PNL_THRESHOLD")
+SYMBOL_PNL_THRESHOLD = float(_sym_pnl_thresh) if _sym_pnl_thresh is not None else None
+
 # Price stagnation detection parameters. If price movement stays below
 # ``STAGNATION_THRESHOLD_PCT`` for ``STAGNATION_DURATION_SEC`` seconds, the
 # position will be closed.


### PR DESCRIPTION
## Summary
- add configurable SYMBOL_PNL_THRESHOLD setting
- track cumulative PnL per symbol and persist it in TradeManager state
- skip opening trades for symbols whose cumulative PnL falls below threshold
- add test covering PnL threshold behavior

## Testing
- `PYTHONPATH=. pytest tests/test_trade_manager.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b5aa64a9ec832ca740c76a4fb8f22d