### PR TITLE
Check symbol resolver before OHLCV fetches

### DIFF
--- a/data_fetcher.py
+++ b/data_fetcher.py
@@ -640,6 +640,9 @@ def fetch_ohlcv_smart(symbol, interval="15m", limit=None, cache_limit=None, **kw
     for source in DATA_SOURCES:
         try:
             if source == "coinbase":
+                if not resolve_symbol_coinbase(symbol):
+                    logger.info(f"⏭️ Skipping Coinbase for {symbol} (unresolved)")
+                    continue
                 logger.info(f"⚡ Trying Coinbase for {symbol}")
                 df = fetch_coinbase_ohlcv(symbol, **params)
                 if len(df) >= 60:
@@ -657,12 +660,18 @@ def fetch_ohlcv_smart(symbol, interval="15m", limit=None, cache_limit=None, **kw
                 ]
 
             elif source == "binance_us":
+                if not resolve_symbol_binance_us(symbol):
+                    logger.info(f"⏭️ Skipping Binance.US for {symbol} (unresolved)")
+                    continue
                 logger.info(f"⚡ Trying Binance.US for {symbol}")
                 df = fetch_binance_us_ohlcv(symbol, **params)
                 if not df.empty:
                     return df
 
             elif source == "binance":
+                if not resolve_symbol_binance_global(symbol):
+                    logger.info(f"⏭️ Skipping Binance for {symbol} (unresolved or blocked)")
+                    continue
                 logger.info(f"⚡ Trying Binance for {symbol}")
                 df = fetch_binance_ohlcv(symbol, **params)
                 if not df.empty:


### PR DESCRIPTION
## Summary
- Skip Coinbase, Binance.US, or Binance OHLCV fetch attempts when the symbol resolver lacks a mapping or the exchange is blocked
- Log a concise message for each skipped source to keep output tidy

## Testing
- `pytest -q` *(fails: ProxyError to blockchain.info)*

------
https://chatgpt.com/codex/tasks/task_e_68b5bc85ed48832cb23b99e73210bc65