### PR TITLE
Specify yfinance auto_adjust to avoid FutureWarning

### DIFF
--- a/data_fetcher.py
+++ b/data_fetcher.py
@@ -948,7 +948,11 @@ def fetch_from_yfinance(symbol, interval="1h", days=10, limit=None):
         try:
             logger.info(f"🔎 Trying yfinance ticker: {yf_symbol}")
             df = yf.download(
-                yf_symbol, period=f"{days}d", interval=yf_interval, progress=False
+                yf_symbol,
+                period=f"{days}d",
+                interval=yf_interval,
+                progress=False,
+                auto_adjust=False,
             )
             if not df.empty and "Close" in df.columns and df["Close"].dropna().shape[0] > 0:
                 df = df.rename(

--- a/tests/test_yfinance_integration.py
+++ b/tests/test_yfinance_integration.py
@@ -22,10 +22,11 @@ import pytest
 def test_fetch_from_yfinance_interval(monkeypatch, interval, expected):
     called = {}
 
-    def fake_download(ticker, period, interval, progress):
+    def fake_download(ticker, period, interval, progress, auto_adjust):
         called["ticker"] = ticker
         called["period"] = period
         called["interval"] = interval
+        called["auto_adjust"] = auto_adjust
         df = _fake_df().copy()
         df.set_index("Timestamp", inplace=True)
         return df
@@ -33,6 +34,7 @@ def test_fetch_from_yfinance_interval(monkeypatch, interval, expected):
     monkeypatch.setattr(data_fetcher.yf, "download", fake_download)
     df = data_fetcher.fetch_from_yfinance("btc", interval=interval, days=1)
     assert called["interval"] == expected
+    assert called["auto_adjust"] is False
     assert not df.empty
     assert "Timestamp" in df.columns
 


### PR DESCRIPTION
## Summary
- Add explicit `auto_adjust=False` to `yf.download` to retain raw prices and silence upcoming FutureWarning
- Update tests to expect `auto_adjust` usage

## Testing
- `pytest -q` *(fails: ProxyError contacting api.blockchain.info)*
- `python - <<'PY'
import data_fetcher
print('Fetching BTC data from yfinance...')
try:
    df = data_fetcher.fetch_from_yfinance('btc', interval='1h', days=1)
    print(df.head())
    print('rows:', len(df))
except Exception as e:
    print('Error:', e)
PY` *(ProxyError fetching data; no FutureWarning observed)*

------
https://chatgpt.com/codex/tasks/task_e_68b5bc6a42fc832cb95f99044289ebe1