### PR TITLE
Fix Blockchain.com active addresses slug

### DIFF
--- a/data_fetcher.py
+++ b/data_fetcher.py
@@ -79,7 +79,7 @@ def fetch_onchain_metrics(days=14):
         "BLOCKCHAIN_CHARTS_BASE", "https://api.blockchain.info/charts"
     )
     tx_url = f"{base_url}/n-transactions"
-    active_url = f"{base_url}/active-addresses"
+    active_url = f"{base_url}/activeaddresses"
     params = {"timespan": f"{days}days", "format": "json", "cors": "true"}
 
     # Only retry on server errors for these endpoints
@@ -237,7 +237,7 @@ def fetch_onchain_metrics(days=14):
     ):
         df_active = _parse_blockchain_chart(active_data, "ActiveAddresses")
     else:
-        df_active = _scrape_chart("active-addresses", "ActiveAddresses")
+        df_active = _scrape_chart("activeaddresses", "ActiveAddresses")
         if df_active is None or df_active.empty:
             df_active = _default_df("ActiveAddresses")
             missing = True

--- a/tests/test_blockchain_chart_endpoints.py
+++ b/tests/test_blockchain_chart_endpoints.py
@@ -24,4 +24,4 @@ def test_transactions_chart_endpoint():
 
 
 def test_active_addresses_chart_endpoint():
-    _get_chart("active-addresses")
+    _get_chart("activeaddresses")

--- a/tests/test_data_fetcher_warnings.py
+++ b/tests/test_data_fetcher_warnings.py
@@ -24,7 +24,7 @@ def test_no_future_warning_on_timestamp_parsing(monkeypatch, tmp_path):
             return fg_sample
         if "n-transactions" in url:
             return tx_sample
-        if "active-addresses" in url:
+        if "activeaddresses" in url:
             return active_sample
         return None
 

--- a/tests/test_onchain_chart_slugs.py
+++ b/tests/test_onchain_chart_slugs.py
@@ -10,7 +10,7 @@ def test_fetch_onchain_metrics_uses_new_chart_slugs(monkeypatch, tmp_path):
         captured.append((url, params))
         if "n-transactions" in url:
             return sample_tx
-        if "active-addresses" in url:
+        if "activeaddresses" in url:
             return sample_active
         return None
 
@@ -21,7 +21,7 @@ def test_fetch_onchain_metrics_uses_new_chart_slugs(monkeypatch, tmp_path):
     df = data_fetcher.fetch_onchain_metrics(days=1)
 
     assert any("n-transactions" in url for url, _ in captured)
-    assert any("active-addresses" in url for url, _ in captured)
+    assert any("activeaddresses" in url for url, _ in captured)
     assert all(
         params.get("format") == "json"
         and params.get("cors") == "true"


### PR DESCRIPTION
## Summary
- fix on-chain metrics to call `activeaddresses` chart
- adjust tests for updated Blockchain.com slug

## Testing
- `pytest -q` *(fails: ProxyError to api.blockchain.info)*
- `python main.py --no-audit-file` *(no 404 warnings; bot skipped scan due to risk thresholds)*
- `python - <<'PY'
from data_fetcher import fetch_onchain_metrics
fetch_onchain_metrics(days=1)
PY` *(403 response from api.blockchain.info but no 404)*

------
https://chatgpt.com/codex/tasks/task_e_68b5bc68c7c4832c9addca09fa283c32