### PR TITLE
feat: add toggle for Binance Global

### DIFF
--- a/config.py
+++ b/config.py
@@ -4,6 +4,10 @@ import os
 # uses the sandbox/testnet APIs.  Default to paper trading for safety.
 TRADING_MODE = os.getenv("TRADING_MODE", "paper").lower()
 
+# Toggle access to Binance Global APIs. Disabled by default to avoid
+# unnecessary requests in regions where the service is unavailable.
+ENABLE_BINANCE_GLOBAL = os.getenv("ENABLE_BINANCE_GLOBAL", "0") == "1"
+
 # Lowest allowed momentum tier (1=strongest, 4=weakest).
 # Assets with a tier value higher than this will be skipped.
 # The default of ``4`` temporarily admits all tiers so we can analyze score

--- a/symbol_resolver.py
+++ b/symbol_resolver.py
@@ -7,6 +7,7 @@ from config import (
     MIN_HOLD_BUCKET,
     MIN_24H_VOLUME,
     WIN_RATE_WEIGHT,
+    ENABLE_BINANCE_GLOBAL,
 )
 from analytics import performance as perf_utils
 
@@ -30,6 +31,12 @@ def _bucket_index(bucket: str) -> int:
 
 def load_binance_global_symbols():
     global BINANCE_GLOBAL_SYMBOLS, BINANCE_GLOBAL_UNAVAILABLE
+    if not ENABLE_BINANCE_GLOBAL:
+        if not BINANCE_GLOBAL_UNAVAILABLE:
+            logger.info("ℹ️ Binance Global disabled via config")
+            BINANCE_GLOBAL_UNAVAILABLE = True
+        return
+
     if BINANCE_GLOBAL_UNAVAILABLE or BINANCE_GLOBAL_SYMBOLS:
         return
 
@@ -46,7 +53,9 @@ def load_binance_global_symbols():
             if sym["status"] == "TRADING" and sym["quoteAsset"] == "USDT":
                 BINANCE_GLOBAL_SYMBOLS[sym["baseAsset"]] = sym["symbol"]
     except Exception as e:
-        logger.error("❌ Failed to load Binance Global symbols: %s - %s", type(e).__name__, e)
+        logger.error(
+            "❌ Failed to load Binance Global symbols: %s - %s", type(e).__name__, e
+        )
 
 def load_binance_us_symbols():
     global BINANCE_US_SYMBOLS


### PR DESCRIPTION
## Summary
- add `ENABLE_BINANCE_GLOBAL` flag to configuration
- skip Binance Global symbol and OHLCV requests when disabled and log once
- adjust data sources to respect Binance Global toggle

## Testing
- `ENABLE_BINANCE_GLOBAL=1 pytest` *(fails: ProxyError in blockchain chart endpoint tests)*

------
https://chatgpt.com/codex/tasks/task_e_68b5c00fd198832c9b41083cec2353b7