### PR TITLE
Improve training data resilience and volume filtering

### DIFF
--- a/feature_engineer.py
+++ b/feature_engineer.py
@@ -20,10 +20,19 @@ from utils.logging import get_logger
 
 logger = get_logger(__name__)
 
-# Minimum rows required after indicator calculations
-MIN_ROWS_AFTER_INDICATORS = 60
+DEFAULT_MIN_ROWS_AFTER_INDICATORS = 60
 
-def add_indicators(df, min_rows: int = MIN_ROWS_AFTER_INDICATORS):
+def add_indicators(df, min_rows: int = DEFAULT_MIN_ROWS_AFTER_INDICATORS):
+    """Add technical and sentiment indicators to OHLCV data.
+
+    Parameters
+    ----------
+    df : :class:`pandas.DataFrame`
+        Raw OHLCV data.
+    min_rows : int, default ``DEFAULT_MIN_ROWS_AFTER_INDICATORS``
+        Minimum number of rows required after indicator computation. If fewer
+        rows remain, an empty DataFrame is returned.
+    """
     if df.empty or "Close" not in df.columns:
         logger.warning("⚠️ Cannot add indicators: DataFrame empty or missing 'Close'")
         return pd.DataFrame()
@@ -303,7 +312,7 @@ def add_indicators(df, min_rows: int = MIN_ROWS_AFTER_INDICATORS):
     return df
 
 
-async def add_indicators_async(df, min_rows: int = MIN_ROWS_AFTER_INDICATORS):
+async def add_indicators_async(df, min_rows: int = DEFAULT_MIN_ROWS_AFTER_INDICATORS):
     """Run :func:`add_indicators` in a background thread."""
     return await asyncio.to_thread(add_indicators, df, min_rows=min_rows)
 

--- a/tests/test_backtester.py
+++ b/tests/test_backtester.py
@@ -76,7 +76,7 @@ def test_backtest_symbol_generates_positive_return(monkeypatch):
     })
 
     monkeypatch.setattr(backtester, 'fetch_ohlcv_smart', lambda symbol, days, limit: df[['Timestamp', 'Open', 'High', 'Low', 'Close']])
-    monkeypatch.setattr(backtester, 'add_indicators', lambda raw_df: df)
+    monkeypatch.setattr(backtester, 'add_indicators', lambda raw_df, **k: df)
     monkeypatch.setattr(backtester, 'add_atr', lambda x, period=14: x)
 
     call_state = {'n': 0}
@@ -115,7 +115,7 @@ def test_backtest_symbol_applies_fee(monkeypatch):
     })
 
     monkeypatch.setattr(backtester, 'fetch_ohlcv_smart', lambda symbol, days, limit: df[['Timestamp', 'Open', 'High', 'Low', 'Close']])
-    monkeypatch.setattr(backtester, 'add_indicators', lambda raw_df: df)
+    monkeypatch.setattr(backtester, 'add_indicators', lambda raw_df, **k: df)
     monkeypatch.setattr(backtester, 'add_atr', lambda x, period=14: x)
 
     call_state = {'n': 0}
@@ -155,7 +155,7 @@ def test_backtest_symbol_respects_execution_delay(monkeypatch):
     })
 
     monkeypatch.setattr(backtester, 'fetch_ohlcv_smart', lambda symbol, days, limit: df[['Timestamp', 'Open', 'Close']])
-    monkeypatch.setattr(backtester, 'add_indicators', lambda raw_df: df)
+    monkeypatch.setattr(backtester, 'add_indicators', lambda raw_df, **k: df)
     monkeypatch.setattr(backtester, 'add_atr', lambda x, period=14: x)
 
     call_state = {'n': 0}
@@ -195,7 +195,7 @@ def test_backtest_symbol_compare(monkeypatch):
     })
 
     monkeypatch.setattr(backtester, 'fetch_ohlcv_smart', lambda symbol, days, limit: df[['Timestamp', 'Open', 'High', 'Low', 'Close']])
-    monkeypatch.setattr(backtester, 'add_indicators', lambda raw_df: df)
+    monkeypatch.setattr(backtester, 'add_indicators', lambda raw_df, **k: df)
     monkeypatch.setattr(backtester, 'add_atr', lambda x, period=14: x)
 
     monkeypatch.setattr(backtester, 'predict_signal', lambda w, t: ('HOLD', 0.6, PredictionClass.SMALL_GAIN.value))

--- a/tests/test_prepare_training_data.py
+++ b/tests/test_prepare_training_data.py
@@ -29,7 +29,7 @@ def test_prepare_training_data_augment(monkeypatch):
     )
     df = _make_df(returns)
     monkeypatch.setattr(train_real_model, "fetch_ohlcv_smart", lambda *a, **k: df)
-    monkeypatch.setattr(train_real_model, "add_indicators", lambda d: d)
+    monkeypatch.setattr(train_real_model, "add_indicators", lambda d, **k: d)
     monkeypatch.setattr(train_real_model, "load_feature_list", lambda: ["feat"])
 
     X, y = train_real_model.prepare_training_data("SYM", "coin", min_unique_samples=3)
@@ -54,7 +54,7 @@ def test_prepare_training_data_drops_on_few_unique(monkeypatch, caplog):
         features_first[i] = v
     df = _make_df(returns, features_first)
     monkeypatch.setattr(train_real_model, "fetch_ohlcv_smart", lambda *a, **k: df)
-    monkeypatch.setattr(train_real_model, "add_indicators", lambda d: d)
+    monkeypatch.setattr(train_real_model, "add_indicators", lambda d, **k: d)
     monkeypatch.setattr(train_real_model, "load_feature_list", lambda: ["feat"])
 
     with caplog.at_level("WARNING", logger=train_real_model.logger.name):
@@ -78,7 +78,7 @@ def test_prepare_training_data_passes_when_threshold_lowered(monkeypatch):
         features_first[i] = v
     df = _make_df(returns, features_first)
     monkeypatch.setattr(train_real_model, "fetch_ohlcv_smart", lambda *a, **k: df)
-    monkeypatch.setattr(train_real_model, "add_indicators", lambda d: d)
+    monkeypatch.setattr(train_real_model, "add_indicators", lambda d, **k: d)
     monkeypatch.setattr(train_real_model, "load_feature_list", lambda: ["feat"])
 
     X, y = train_real_model.prepare_training_data("SYM", "coin", min_unique_samples=3)
@@ -102,7 +102,7 @@ def test_prepare_training_data_drops_when_insufficient_rows(monkeypatch, caplog)
 
     called = {"add": False}
 
-    def fake_add(d):
+    def fake_add(d, **k):
         called["add"] = True
         return d
 

--- a/tests/test_scan_for_breakouts.py
+++ b/tests/test_scan_for_breakouts.py
@@ -55,7 +55,7 @@ def test_scan_for_breakouts_opens_trade(monkeypatch):
         lambda limit=15: [("id1", "ABC", "ABC Coin", 10.0, 1_000_000)],
     )
     monkeypatch.setattr(main, "fetch_ohlcv_smart", lambda *a, **k: _mock_df())
-    monkeypatch.setattr(main, "add_indicators", lambda d: d)
+    monkeypatch.setattr(main, "add_indicators", lambda d, **k: d)
     monkeypatch.setattr(main, "predict_signal", lambda df, threshold: ("BUY", 0.95, 4))
     monkeypatch.setattr(main, "get_dynamic_threshold", lambda vol, base: 0.5)
 
@@ -134,7 +134,7 @@ def test_low_buy_override_threshold_allows_trade(monkeypatch):
         lambda limit=15: [("id1", "ABC", "ABC Coin", 10.0, 1_000_000)],
     )
     monkeypatch.setattr(main, "fetch_ohlcv_smart", lambda *a, **k: _mock_df())
-    monkeypatch.setattr(main, "add_indicators", lambda d: d)
+    monkeypatch.setattr(main, "add_indicators", lambda d, **k: d)
 
     def fake_predict(df, threshold):
         return ("BUY" if 0.7 >= main.HIGH_CONF_BUY_OVERRIDE else "HOLD", 0.7, 3)
@@ -176,7 +176,7 @@ def test_low_volatility_threshold_allows_trade(monkeypatch):
         return df
 
     monkeypatch.setattr(main, "fetch_ohlcv_smart", lambda *a, **k: low_vol_df())
-    monkeypatch.setattr(main, "add_indicators", lambda d: d)
+    monkeypatch.setattr(main, "add_indicators", lambda d, **k: d)
     monkeypatch.setattr(main, "predict_signal", lambda df, threshold: ("BUY", 0.95, 4))
     monkeypatch.setattr(main, "get_dynamic_threshold", lambda vol, base: 0.5)
 
@@ -229,7 +229,7 @@ def test_scan_for_breakouts_blocks_correlated_entries(monkeypatch):
         return df
 
     monkeypatch.setattr(main, "fetch_ohlcv_smart", fetch)
-    monkeypatch.setattr(main, "add_indicators", lambda d: d)
+    monkeypatch.setattr(main, "add_indicators", lambda d, **k: d)
     monkeypatch.setattr(main, "predict_signal", lambda df, threshold: ("BUY", 0.95, 4))
     monkeypatch.setattr(main, "get_dynamic_threshold", lambda vol, base: 0.5)
 
@@ -283,7 +283,7 @@ def test_scan_for_breakouts_selects_uncorrelated_candidate(monkeypatch):
         return df
 
     monkeypatch.setattr(main, "fetch_ohlcv_smart", fetch)
-    monkeypatch.setattr(main, "add_indicators", lambda d: d)
+    monkeypatch.setattr(main, "add_indicators", lambda d, **k: d)
 
     def pred(df, threshold):
         trend_up = df["Close"].iloc[-1] > df["Close"].iloc[0]

--- a/tests/test_symbol_resolver.py
+++ b/tests/test_symbol_resolver.py
@@ -24,6 +24,7 @@ def test_binance_global_451_warning_logged_once(monkeypatch, caplog):
     # Reset globals and patch request
     monkeypatch.setattr(symbol_resolver, "BINANCE_GLOBAL_SYMBOLS", {})
     monkeypatch.setattr(symbol_resolver, "BINANCE_GLOBAL_UNAVAILABLE", False)
+    monkeypatch.setattr(symbol_resolver, "ENABLE_BINANCE_GLOBAL", True)
     monkeypatch.setattr(symbol_resolver.requests, "get", mock_get)
 
     with caplog.at_level("WARNING"):

--- a/tests/test_trade_manager.py
+++ b/tests/test_trade_manager.py
@@ -101,7 +101,7 @@ def test_unrealized_drawdown_reduces_allocation(monkeypatch):
     tm.trade_fee_pct = 0.0
     df = mock_indicator_df()
     monkeypatch.setattr('data_fetcher.fetch_ohlcv_smart', lambda *a, **k: df)
-    monkeypatch.setattr('feature_engineer.add_indicators', lambda d: d)
+    monkeypatch.setattr('feature_engineer.add_indicators', lambda d, **k: d)
 
     tm.open_trade('ABC', 10.0, confidence=1.0)
 
@@ -136,7 +136,7 @@ def test_open_trade_uses_atr_for_stops(monkeypatch):
     tm.risk_per_trade = 1.0
     df = mock_indicator_df()
     monkeypatch.setattr('data_fetcher.fetch_ohlcv_smart', lambda *a, **k: df)
-    monkeypatch.setattr('feature_engineer.add_indicators', lambda d: d)
+    monkeypatch.setattr('feature_engineer.add_indicators', lambda d, **k: d)
     price = 10.0
     tm.open_trade('ABC', price, confidence=1.0)
     pos = tm.positions['ABC']
@@ -151,7 +151,7 @@ def test_close_trade_records_rotation_price(monkeypatch):
     tm.risk_per_trade = 1.0
     df = mock_indicator_df()
     monkeypatch.setattr('data_fetcher.fetch_ohlcv_smart', lambda *a, **k: df)
-    monkeypatch.setattr('feature_engineer.add_indicators', lambda d: d)
+    monkeypatch.setattr('feature_engineer.add_indicators', lambda d, **k: d)
     tm.open_trade('ABC', 10.0, confidence=1.0)
     tm.close_trade(
         'ABC',
@@ -171,7 +171,7 @@ def test_rotation_aborted_when_gain_insufficient(monkeypatch):
     tm.risk_per_trade = 1.0
     df = mock_indicator_df()
     monkeypatch.setattr('data_fetcher.fetch_ohlcv_smart', lambda *a, **k: df)
-    monkeypatch.setattr('feature_engineer.add_indicators', lambda d: d)
+    monkeypatch.setattr('feature_engineer.add_indicators', lambda d, **k: d)
     tm.open_trade('ABC', 10.0, confidence=1.0)
     closed = tm.close_trade(
         'ABC',
@@ -189,7 +189,7 @@ def test_rotation_executes_when_gain_covers_cost(monkeypatch):
     tm.risk_per_trade = 1.0
     df = mock_indicator_df()
     monkeypatch.setattr('data_fetcher.fetch_ohlcv_smart', lambda *a, **k: df)
-    monkeypatch.setattr('feature_engineer.add_indicators', lambda d: d)
+    monkeypatch.setattr('feature_engineer.add_indicators', lambda d, **k: d)
     tm.open_trade('ABC', 10.0, confidence=1.0)
     closed = tm.close_trade(
         'ABC',
@@ -207,7 +207,7 @@ def test_rotation_aborted_when_net_gain_below_margin(monkeypatch):
     tm = create_tm()
     df = mock_indicator_df()
     monkeypatch.setattr('data_fetcher.fetch_ohlcv_smart', lambda *a, **k: df)
-    monkeypatch.setattr('feature_engineer.add_indicators', lambda d: d)
+    monkeypatch.setattr('feature_engineer.add_indicators', lambda d, **k: d)
     tm.open_trade('ABC', 10.0, confidence=1.0)
 
     # Force projected gain to barely exceed cost but not the safety margin
@@ -227,7 +227,7 @@ def test_rotation_outcome_logging(monkeypatch, caplog):
     tm = create_tm()
     df = mock_indicator_df()
     monkeypatch.setattr('data_fetcher.fetch_ohlcv_smart', lambda *a, **k: df)
-    monkeypatch.setattr('feature_engineer.add_indicators', lambda d: d)
+    monkeypatch.setattr('feature_engineer.add_indicators', lambda d, **k: d)
 
     tm.open_trade('ABC', 10.0, confidence=1.0)
     tm.close_trade(
@@ -262,7 +262,7 @@ def test_slippage_applied_to_trade(monkeypatch):
     tm.slippage_pct = 0.01
     df = mock_indicator_df()
     monkeypatch.setattr('data_fetcher.fetch_ohlcv_smart', lambda *a, **k: df)
-    monkeypatch.setattr('feature_engineer.add_indicators', lambda d: d)
+    monkeypatch.setattr('feature_engineer.add_indicators', lambda d, **k: d)
     price = 10.0
     tm.open_trade('ABC', price, confidence=1.0)
     pos = tm.positions['ABC']
@@ -282,7 +282,7 @@ def test_hold_period_delays_exits(monkeypatch):
     tm.sl_buffer_atr_mult = 0.0
     df = mock_indicator_df()
     monkeypatch.setattr('data_fetcher.fetch_ohlcv_smart', lambda *a, **k: df)
-    monkeypatch.setattr('feature_engineer.add_indicators', lambda d: d)
+    monkeypatch.setattr('feature_engineer.add_indicators', lambda d, **k: d)
 
     tm.open_trade('ABC', 10.0, confidence=1.0)
     pos = tm.positions['ABC']
@@ -310,7 +310,7 @@ def test_close_trade_respects_hold_bucket(monkeypatch):
     tm.trade_fee_pct = 0.01
     df = mock_indicator_df()
     monkeypatch.setattr('data_fetcher.fetch_ohlcv_smart', lambda *a, **k: df)
-    monkeypatch.setattr('feature_engineer.add_indicators', lambda d: d)
+    monkeypatch.setattr('feature_engineer.add_indicators', lambda d, **k: d)
 
     tm.open_trade('ABC', 10.0, confidence=1.0)
     pos = tm.positions['ABC']
@@ -338,7 +338,7 @@ def test_stagnation_closes_position(monkeypatch):
 
     df = mock_indicator_df()
     monkeypatch.setattr('data_fetcher.fetch_ohlcv_smart', lambda *a, **k: df)
-    monkeypatch.setattr('feature_engineer.add_indicators', lambda d: d)
+    monkeypatch.setattr('feature_engineer.add_indicators', lambda d, **k: d)
 
     tm.open_trade('ABC', 100.0, confidence=1.0)
     pos = tm.positions['ABC']
@@ -458,7 +458,7 @@ def test_adaptive_stagnation_logs_scaled_threshold(monkeypatch, caplog):
         'Hist': [0.1, 0.1, 0.1],
     })
     monkeypatch.setattr('data_fetcher.fetch_ohlcv_smart', lambda *a, **k: dummy_df)
-    monkeypatch.setattr('feature_engineer.add_indicators', lambda d: d)
+    monkeypatch.setattr('feature_engineer.add_indicators', lambda d, **k: d)
 
     with caplog.at_level(logging.INFO, logger='trade_manager'):
         tm.manage('ABC', current_price)
@@ -475,7 +475,7 @@ def test_skips_trade_when_profit_insufficient(monkeypatch):
 
     df = pd.DataFrame({'ATR': [0.01]})
     monkeypatch.setattr('data_fetcher.fetch_ohlcv_smart', lambda *a, **k: df)
-    monkeypatch.setattr('feature_engineer.add_indicators', lambda d: d)
+    monkeypatch.setattr('feature_engineer.add_indicators', lambda d, **k: d)
 
     tm.open_trade('ABC', 10.0, confidence=1.0)
     assert 'ABC' not in tm.positions
@@ -495,7 +495,7 @@ def test_open_trade_respects_confidence_threshold(monkeypatch):
     tm.risk_per_trade = 1.0
     df = mock_indicator_df()
     monkeypatch.setattr('data_fetcher.fetch_ohlcv_smart', lambda *a, **k: df)
-    monkeypatch.setattr('feature_engineer.add_indicators', lambda d: d)
+    monkeypatch.setattr('feature_engineer.add_indicators', lambda d, **k: d)
 
     tm.open_trade('ABC', 10.0, confidence=0.6)
     assert 'ABC' not in tm.positions
@@ -512,7 +512,7 @@ def test_open_trade_enforces_hold_period(monkeypatch):
     tm.trade_fee_pct = 0.0
     df = mock_indicator_df()
     monkeypatch.setattr('data_fetcher.fetch_ohlcv_smart', lambda *a, **k: df)
-    monkeypatch.setattr('feature_engineer.add_indicators', lambda d: d)
+    monkeypatch.setattr('feature_engineer.add_indicators', lambda d, **k: d)
 
     tm.open_trade('ABC', 10.0, confidence=1.0)
     tm.open_trade('DEF', 5.0, confidence=1.0)
@@ -619,7 +619,7 @@ def test_close_trade_skips_when_profit_ratio_low(monkeypatch):
         'atr': None,
     }
     monkeypatch.setattr('data_fetcher.fetch_ohlcv_smart', lambda *a, **k: mock_indicator_df())
-    monkeypatch.setattr('feature_engineer.add_indicators', lambda d: d)
+    monkeypatch.setattr('feature_engineer.add_indicators', lambda d, **k: d)
 
     tm.close_trade('ABC', 100.5, reason='Take-Profit')
     assert tm.has_position('ABC')
@@ -660,7 +660,7 @@ def test_blacklist_skips_trade(monkeypatch):
 
     df = mock_indicator_df()
     monkeypatch.setattr('data_fetcher.fetch_ohlcv_smart', lambda *a, **k: df)
-    monkeypatch.setattr('feature_engineer.add_indicators', lambda d: d)
+    monkeypatch.setattr('feature_engineer.add_indicators', lambda d, **k: d)
 
     # INJ with bucket 5-30m is blacklisted in analytics/trade_stats.csv
     tm.open_trade('INJ', 10.0, confidence=1.0)
@@ -685,7 +685,7 @@ def test_fee_ratio_blacklist(monkeypatch):
 
     df = mock_indicator_df()
     monkeypatch.setattr('data_fetcher.fetch_ohlcv_smart', lambda *a, **k: df)
-    monkeypatch.setattr('feature_engineer.add_indicators', lambda d: d)
+    monkeypatch.setattr('feature_engineer.add_indicators', lambda d, **k: d)
 
     # LINK in the 30m-2h bucket is blacklisted due to historical fee ratio
     tm.open_trade('LINK', 10.0, confidence=1.0)
@@ -707,7 +707,7 @@ def test_symbol_pnl_threshold_skips_symbol(monkeypatch, caplog):
 
     df = mock_indicator_df()
     monkeypatch.setattr('data_fetcher.fetch_ohlcv_smart', lambda *a, **k: df)
-    monkeypatch.setattr('feature_engineer.add_indicators', lambda d: d)
+    monkeypatch.setattr('feature_engineer.add_indicators', lambda d, **k: d)
 
     tm.open_trade('ABC', 10.0, confidence=1.0)
     tm.close_trade('ABC', 5.0, reason='Stop-Loss')


### PR DESCRIPTION
## Summary
- Allow bypassing volume-based filtering with `--ignore-volume` and reduce default `--min-volume`
- Retry symbol downloads with longer history and fallback to alternate sources when indicators yield too few rows
- Document and expose `min_rows` in `add_indicators` for centralized row requirements

## Testing
- `pytest` *(fails: HTTPSConnectionPool(host='api.blockchain.info', port=443): Max retries exceeded)*


------
https://chatgpt.com/codex/tasks/task_e_68b5d4480624832cadaad81f147c4418