### PR TITLE
Handle missing 4h indicators and expose return quantiles

### DIFF
--- a/tests/test_feature_engineer.py
+++ b/tests/test_feature_engineer.py
@@ -90,8 +90,7 @@ def test_add_indicators_insufficient_4h_history(monkeypatch):
     result = add_indicators(df, min_rows=20)
     cols = {'SMA_4h', 'MACD_4h', 'Signal_4h', 'Hist_4h'}
     assert result.empty
-    assert cols.issubset(result.columns)
-    assert result[list(cols)].isna().all().all()
+    assert all(col not in result.columns for col in cols)
 
 
 def test_add_indicators_skips_when_insufficient_rows(monkeypatch, caplog):


### PR DESCRIPTION
## Summary
- guard against timestamp misalignment after feature merges and retry/drop 4h aggregates when they remain NaN
- drop non-finite rows before oversampling and allow custom return quantile thresholds via CLI
- adjust tests for new 4h aggregate behaviour

## Testing
- `pytest` *(fails: tests/test_blockchain_chart_endpoints.py::test_transactions_chart_endpoint, tests/test_blockchain_chart_endpoints.py::test_active_addresses_chart_endpoint, tests/test_symbol_resolver.py::test_binance_global_451_warning_logged_once)*


------
https://chatgpt.com/codex/tasks/task_e_68b5d449e0b4832cb7780dffef758b6e