### PR TITLE
Reset indexes before merging BTC data

### DIFF
--- a/feature_engineer.py
+++ b/feature_engineer.py
@@ -146,7 +146,8 @@ def add_indicators(df, min_rows: int = DEFAULT_MIN_ROWS_AFTER_INDICATORS):
         btc = fetch_ohlcv_smart("BTC", interval="1d", coin_id="bitcoin", days=span_days)
         if not btc.empty and "Close" in btc.columns:
             btc["Timestamp"] = pd.to_datetime(btc["Timestamp"], utc=True)
-            btc = btc.sort_values("Timestamp")
+            btc = btc.sort_values("Timestamp").reset_index(drop=True)
+            df = df.reset_index(drop=True)
             df = pd.merge_asof(
                 df.sort_values("Timestamp"),
                 btc[["Timestamp", "Close"]].rename(columns={"Close": "BTC_Close"}),


### PR DESCRIPTION
## Summary
- ensure Relative Strength vs BTC merges with plain indexes
- add regression test covering cached BTC OHLCV

## Testing
- `PYTHONPATH=$PWD pytest tests/test_feature_engineer.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b5d84d55c8832c9c4b963feb41558f