### PR TITLE
Use shared session in safe_request

### DIFF
--- a/data_fetcher.py
+++ b/data_fetcher.py
@@ -21,6 +21,9 @@ from config import ENABLE_BINANCE_GLOBAL
 
 logger = get_logger(__name__)
 
+# Reuse a single session for connection pooling across requests
+session = requests.Session()
+
 # Status codes for which we retry by default (server errors)
 SERVER_ERROR_CODES = set(range(500, 600))
 SEEN_404_URLS = set()
@@ -404,14 +407,14 @@ def safe_request(
         try:
             req_headers = headers.copy() if headers else None
             if req_headers:
-                r = requests.get(
+                r = session.get(
                     url,
                     params=params,
                     timeout=timeout,
                     headers=req_headers,
                 )
             else:
-                r = requests.get(url, params=params, timeout=timeout)
+                r = session.get(url, params=params, timeout=timeout)
 
             if r.status_code == 401:
                 logger.error(f"❌ 401 Unauthorized {url}")


### PR DESCRIPTION
## Summary
- reuse a module-level `requests.Session`
- update safe_request to leverage the shared session
- add unit test ensuring session is used and headers propagate

## Testing
- `PYTHONPATH=. pytest tests/test_safe_request.py -q`
- `PYTHONPATH=. pytest -q` *(fails: ProxyError: HTTPSConnectionPool(host='api.blockchain.info', port=443))*

------
https://chatgpt.com/codex/tasks/task_e_68b5ec76b708832cb09ea4a2996ba7c2