### PR TITLE
Log confusion matrix for each CV fold

### DIFF
--- a/train_real_model.py
+++ b/train_real_model.py
@@ -562,6 +562,17 @@ def train_model(
                     zero_division=0,
                 ),
             )
+            cm = confusion_matrix(
+                y_val_raw,
+                cv_preds,
+                labels=sorted(fold_le.classes_),
+            )
+            cm_df = pd.DataFrame(
+                cm,
+                index=[fold_label_map[cls] for cls in sorted(fold_le.classes_)],
+                columns=[fold_label_map[cls] for cls in sorted(fold_le.classes_)],
+            )
+            logger.info("🧮 CV Fold %d confusion matrix:\n%s", fold, cm_df)
         except Exception as e:
             logger.warning("⚠️ CV fold %d failed: %s", fold, e)
 


### PR DESCRIPTION
## Summary
- Log confusion matrices alongside classification reports for each cross-validation fold in `train_real_model.py` to aid in analyzing misclassifications.

## Testing
- `python train_real_model.py --oversampler adasyn --max-assets 1 --fast --cv-splits 3` *(failed: ProxyError 403 Forbidden when fetching data)*
- `pytest` *(failed: requests.exceptions.ProxyError due to 403 Forbidden during network calls)*

------
https://chatgpt.com/codex/tasks/task_e_68b5ec7435e0832ca7a921dd93642419