### PR TITLE
Handle missing on-chain metrics API

### DIFF
--- a/tests/test_feature_engineer.py
+++ b/tests/test_feature_engineer.py
@@ -46,7 +46,7 @@ def test_add_indicators_merges_sentiment_and_onchain(monkeypatch):
         assert result[col].notna().all()
 
 
-def test_add_indicators_handles_all_nan_onchain(monkeypatch):
+def test_add_indicators_handles_missing_onchain(monkeypatch):
     periods = 120
     dates = pd.date_range('2023-01-01', periods=periods, freq='D')
     df = pd.DataFrame({
@@ -60,17 +60,15 @@ def test_add_indicators_handles_all_nan_onchain(monkeypatch):
         'Timestamp': dates,
         'FearGreed': np.linspace(20, 80, periods)
     })
-    onchain = pd.DataFrame({
-        'Timestamp': dates,
-        'UnknownMetric': [np.nan] * periods
-    })
 
     monkeypatch.setattr('feature_engineer.fetch_fear_greed_index', lambda limit=365: sentiment)
-    monkeypatch.setattr('feature_engineer.fetch_onchain_metrics', lambda: onchain)
+    monkeypatch.setattr('feature_engineer.fetch_onchain_metrics', lambda: None)
     monkeypatch.setattr('feature_engineer.fetch_ohlcv_smart', lambda *args, **kwargs: pd.DataFrame())
 
     result = add_indicators(df)
     assert len(result) >= 60
+    assert 'TxVolume_norm' not in result.columns
+    assert 'ActiveAddresses_norm' not in result.columns
 
 
 def test_add_indicators_insufficient_4h_history(monkeypatch, caplog):

--- a/tests/test_onchain_auth_fallbacks.py
+++ b/tests/test_onchain_auth_fallbacks.py
@@ -18,8 +18,7 @@ def test_fetch_onchain_metrics_missing_api_key(monkeypatch, tmp_path):
     os.makedirs(data_fetcher.CACHE_DIR, exist_ok=True)
 
     df = data_fetcher.fetch_onchain_metrics(days=2)
-    assert not df.empty
-    assert (df["TxVolume"] == 0).all() and (df["ActiveAddresses"] == 0).all()
+    assert df is None
     assert calls["count"] == 0
 
 


### PR DESCRIPTION
## Summary
- Return `None` from `fetch_onchain_metrics` when `BLOCKCHAIN_API_KEY` is absent
- Skip on-chain feature engineering when metrics are missing
- Update tests for missing API key and optional on-chain features

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'filelock')*

------
https://chatgpt.com/codex/tasks/task_e_68b5ef1b6d44832c90a5a9b55b60dc7c