### PR TITLE
Treat unknown history as insufficient

### DIFF
--- a/data_fetcher.py
+++ b/data_fetcher.py
@@ -645,13 +645,13 @@ def has_min_history(
 
     Returns a tuple ``(ok, count)`` where ``count`` may be ``None`` if the
     number of candles could not be determined (network failure or unknown
-    symbol).  In such cases ``ok`` is ``True`` so callers do not drop symbols
-    due to an inconclusive check.
+    symbol).  In such cases ``ok`` is ``False`` so callers can skip symbols
+    when the available history is unknown.
     """
 
     count = _quick_head_count(symbol, interval)
     if count is None:
-        return True, None
+        return False, None
     return count >= min_bars, count
 
 # =========================================================

--- a/tests/test_prepare_training_data.py
+++ b/tests/test_prepare_training_data.py
@@ -8,6 +8,15 @@ sys.path.append(os.path.dirname(os.path.dirname(__file__)))
 import train_real_model
 
 
+@pytest.fixture(autouse=True)
+def _mock_min_history(monkeypatch):
+    monkeypatch.setattr(
+        train_real_model.data_fetcher,
+        "has_min_history",
+        lambda *a, **k: (True, 1000),
+    )
+
+
 def _make_df(returns, features_first=None):
     prices = [100, 100, 100]
     for i, r in enumerate(returns):
@@ -178,3 +187,11 @@ def test_prepare_training_data_skips_insufficient_4h(monkeypatch, caplog):
     assert X is None and y is None
     assert not called["add"]
     assert any("4h" in r.getMessage() for r in caplog.records)
+
+
+def test_prepare_training_data_skips_when_no_history(monkeypatch):
+    monkeypatch.setattr(
+        train_real_model.data_fetcher, "has_min_history", lambda *a, **k: (False, None)
+    )
+    X, y = train_real_model.prepare_training_data("SYM", "coin")
+    assert X is None and y is None

--- a/train_real_model.py
+++ b/train_real_model.py
@@ -181,7 +181,11 @@ def prepare_training_data(
     ok, count = data_fetcher.has_min_history(symbol, min_bars=416, interval="15m")
     if not ok:
         if coin_id not in _SHORT_HISTORY_LOGGED:
-            logger.info("⏭️ Skipping %s (%d 15m candles)", coin_id, count)
+            logger.info(
+                "⏭️ Skipping %s (%s 15m candles)",
+                coin_id,
+                count if count is not None else "unknown",
+            )
             _SHORT_HISTORY_LOGGED.add(coin_id)
         return None, None
 


### PR DESCRIPTION
## Summary
- treat missing quick history counts as insufficient data
- skip symbols when history is unknown and log count gracefully
- mock history checks in training-data tests and add coverage for no-history case

## Testing
- `pytest tests/test_prepare_training_data.py -q`
- `pytest -q` *(fails: tests/test_blockchain_chart_endpoints.py::test_transactions_chart_endpoint, tests/test_blockchain_chart_endpoints.py::test_active_addresses_chart_endpoint)*

------
https://chatgpt.com/codex/tasks/task_e_68b5fa5c10c0832c8abade26d9b9966e