### PR TITLE
Add configurable horizon for training data

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,9 @@ The feature‑engineering pipeline scales its minimum history requirement with
 the amount of data fetched (60 % by default). This adaptive threshold can be
 customised via the ``min_rows_ratio`` argument to
 ``train_real_model.prepare_training_data`` when integrating the training
-utilities programmatically.
+utilities programmatically.  The prediction horizon defaults to three future
+15‑minute bars (45 minutes) but can be adjusted with the ``horizon`` argument
+or ``--horizon`` CLI flag (e.g. ``--horizon 288`` for roughly three days).
 
 ### Handling Class Imbalance
 

--- a/tests/test_prepare_training_data.py
+++ b/tests/test_prepare_training_data.py
@@ -178,3 +178,43 @@ def test_prepare_training_data_skips_insufficient_4h(monkeypatch, caplog):
     assert X is None and y is None
     assert not called["add"]
     assert any("4h" in r.getMessage() for r in caplog.records)
+
+
+def test_prepare_training_data_horizon(monkeypatch):
+    returns = (
+        [-0.05] * 10
+        + [-0.02] * 10
+        + [0.01] * 10
+        + [0.02] * 10
+        + [0.05] * 30
+    )
+    df = _make_df(returns)
+
+    monkeypatch.setattr(train_real_model, "fetch_ohlcv_smart", lambda *a, **k: df)
+    monkeypatch.setattr(train_real_model, "add_indicators", lambda d, **k: d)
+    monkeypatch.setattr(train_real_model, "load_feature_list", lambda: ["feat"])
+    monkeypatch.setattr(
+        train_real_model.data_fetcher, "has_min_history", lambda *a, **k: (True, 500)
+    )
+
+    captured = {}
+    orig_compute = train_real_model.compute_return_thresholds
+
+    def fake_compute_return_thresholds(series, quantiles):
+        captured["returns"] = series.copy()
+        return orig_compute(series, quantiles)
+
+    monkeypatch.setattr(
+        train_real_model, "compute_return_thresholds", fake_compute_return_thresholds
+    )
+
+    train_real_model.prepare_training_data("SYM", "coin", horizon=5)
+
+    expected = ((df["Close"].shift(-5) - df["Close"]) / df["Close"]).dropna()
+    expected = expected[expected.abs() > 0.005]
+
+    pd.testing.assert_series_equal(
+        captured["returns"].reset_index(drop=True),
+        expected.reset_index(drop=True),
+        check_names=False,
+    )

--- a/train_real_model.py
+++ b/train_real_model.py
@@ -145,6 +145,7 @@ def prepare_training_data(
     min_unique_samples: int = 3,
     augment_target: int = 50,
     quantiles: Iterable[float] = (0.2, 0.4, 0.6, 0.8),
+    horizon: int = 3,
     min_rows: int = 60,
     min_rows_ratio: float = 0.6,
 ):
@@ -167,6 +168,10 @@ def prepare_training_data(
     quantiles: iterable of float, optional
         Percentiles for :func:`compute_return_thresholds`. Adjust to
         influence how return buckets are defined.
+    horizon : int, default ``3``
+        Number of future bars (15m each) to look ahead when computing the
+        target. ``3`` corresponds to 45 minutes, while ``288`` covers roughly
+        3 days.
     min_rows : int, default ``60``
         Baseline minimum number of rows desired before indicator computation.
     min_rows_ratio : float, default ``0.6``
@@ -294,7 +299,9 @@ def prepare_training_data(
             )
             return None, None
 
-    df.loc[:, "Future_Close"] = df["Close"].shift(-3)  # 🔁 3-day ahead for short-term trading
+    df.loc[:, "Future_Close"] = df["Close"].shift(
+        -horizon
+    )  # 🔁 horizon bars ahead (e.g., 45m for horizon=3)
     df.loc[:, "Return"] = (df["Future_Close"] - df["Close"]) / df["Close"]
     df = df[df["Return"].abs() > 0.005]
     df = df.dropna()
@@ -832,6 +839,12 @@ def main():
         help="Quantiles for return thresholds (four floats between 0 and 1)",
     )
     parser.add_argument(
+        "--horizon",
+        type=int,
+        default=3,
+        help="Number of future 15m bars to predict (e.g., 3 for 45m, 288 for ~3d)",
+    )
+    parser.add_argument(
         "--fast",
         action="store_true",
         help="Use a smaller hyperparameter grid for quicker runs",
@@ -924,6 +937,7 @@ def main():
             min_unique_samples=args.min_unique_samples,
             augment_target=args.augment_target,
             quantiles=args.quantiles,
+            horizon=args.horizon,
         )
         if X is not None and y is not None:
             logger.info("✅ Selected %s for training", symbol.upper())


### PR DESCRIPTION
## Summary
- add `horizon` parameter to `prepare_training_data` and make target shifting configurable
- expose `--horizon` in `train_real_model.py` CLI and document usage
- test that horizon correctly determines future-return calculation

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b5fa5d52c0832c8b13e666e8a96d50