### PR TITLE
Use time-aware oversampling for training

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ This repository contains utilities for analyzing cryptocurrency markets and auto
 - Python 3.10+
 - Google Chrome or Chromium and the matching ChromeDriver for features that rely on Selenium (e.g., scraping CoinMarketCap). Ensure both are installed and available on your `PATH`; otherwise, scraping features will return no data.
 - TA-Lib C library.
-- imbalanced-learn>=0.11 for optional SMOTE/ADASYN oversampling.
+- imbalanced-learn>=0.11 for optional oversampling techniques.
 
 ## Installation
 
@@ -63,15 +63,27 @@ utilities programmatically.
 
 ### Handling Class Imbalance
 
-The training pipeline now applies **SMOTE** oversampling by default to
-improve recall for rare classes. It relies on the [`imbalanced-learn`](https://imbalanced-learn.org/) package,
-which is installed via `requirements.txt`. You can switch to **ADASYN** with:
+Time‑series data makes synthetic sampling tricky. By default the training
+script applies **RandomOverSampler**, which simply duplicates existing rows and
+preserves temporal order. This requires the
+[`imbalanced-learn`](https://imbalanced-learn.org/) package.
+
+To rely solely on class weighting (no oversampling):
 
 ```bash
-python train_real_model.py --oversampler adasyn
+python train_real_model.py --oversampler none
 ```
-Cross‑validation shows that SMOTE yielded the best minority‑class recall in
-our experiments.
+
+Other strategies like **SMOTE** or **ADASYN** are available but may introduce
+temporal leakage because they interpolate between points. Use them only if the
+time dependence is negligible:
+
+```bash
+python train_real_model.py --oversampler smote  # or adasyn/borderline
+```
+
+Choose a strategy based on how strictly you need to preserve chronology in
+your data.
 
 ## Engineered Features
 

--- a/tests/test_train_model_oversampling.py
+++ b/tests/test_train_model_oversampling.py
@@ -8,10 +8,10 @@ sys.path.append(os.path.dirname(os.path.dirname(__file__)))
 from train_real_model import train_model
 
 
-def test_train_model_runs_with_smote():
+def test_train_model_runs_with_random_oversampler():
     # Create deterministic synthetic dataset with 5 classes
     n_classes = 5
-    samples_per_class = 10  # ensures sufficient samples for SMOTE
+    samples_per_class = 10  # ensures sufficient samples for oversampling
     y = pd.Series(np.tile(np.arange(n_classes), samples_per_class))
     X = pd.DataFrame({
         "feat1": np.arange(len(y)),
@@ -21,7 +21,7 @@ def test_train_model_runs_with_smote():
     model, labels = train_model(
         X,
         y,
-        oversampler="smote",
+        oversampler="random",
         param_scale="small",
         cv_splits=2,
         verbose=0,

--- a/train_real_model.py
+++ b/train_real_model.py
@@ -154,7 +154,7 @@ def prepare_training_data(
     ----------
     symbol, coin_id: str
         Asset identifiers used for data fetching.
-    oversampler: {"smote", "adasyn", "borderline", "random"}, optional
+    oversampler: {"random", "smote", "adasyn", "borderline"}, optional
         Technique for oversampling minority classes.  ``None`` disables
         oversampling.
     min_unique_samples: int, default ``3``
@@ -335,7 +335,7 @@ def prepare_training_data(
     X = df[[c for c in feature_cols if c in df.columns]]
     y = df["Target"]
 
-    # Optional oversampling with SMOTE variants
+    # Optional oversampling with imbalanced-learn methods
     class_counts = y.value_counts()
     rare_classes = [cls for cls, cnt in class_counts.items() if cnt < augment_target]
     if oversampler in {"smote", "adasyn", "borderline", "random"} and rare_classes:
@@ -408,7 +408,7 @@ def prepare_training_data(
 def train_model(
     X,
     y,
-    oversampler: Optional[str] = None,
+    oversampler: Optional[str] = "random",
     param_scale: str = "full",
     cv_splits: int = 3,
     verbose: int = 1,
@@ -800,9 +800,11 @@ def main():
     )
     parser.add_argument(
         "--oversampler",
-        choices=["smote", "adasyn", "borderline", "random", "none"],
-        default="smote",
-        help="Apply oversampling technique to minority classes",
+        choices=["random", "smote", "adasyn", "borderline", "none"],
+        default="random",
+        help=(
+            "Resampling strategy: 'random' duplicates minority samples, 'none' relies on class weights"
+        ),
     )
     parser.add_argument(
         "--class-weight",


### PR DESCRIPTION
## Summary
- default training oversampler now uses imblearn's RandomOverSampler
- expose oversampler choice with `--oversampler` and document time-series resampling strategies
- update tests to exercise new oversampling path

## Testing
- `pytest tests/test_train_model_oversampling.py -q`
- `pytest -q` *(fails: ProxyError: HTTPSConnectionPool(host='api.blockchain.info', port=443))*

------
https://chatgpt.com/codex/tasks/task_e_68b5fa605490832caa08ffbf6fbe605d