### PR TITLE
Add controls for threshold spacing and oversampling

### DIFF
--- a/tests/test_prepare_training_data.py
+++ b/tests/test_prepare_training_data.py
@@ -44,11 +44,13 @@ def test_prepare_training_data_augment(monkeypatch):
     monkeypatch.setattr(train_real_model, "add_indicators", lambda d, **k: d)
     monkeypatch.setattr(train_real_model, "load_feature_list", lambda: ["feat"])
 
-    X, y = train_real_model.prepare_training_data("SYM", "coin", min_unique_samples=3)
+    X, y = train_real_model.prepare_training_data(
+        "SYM", "coin", min_unique_samples=3, augment_ratio=1.0
+    )
     assert X is not None and y is not None
     counts = y.value_counts().to_dict()
-    assert counts[0] == 28
-    assert counts[4] == 32
+    assert counts[0] == 16
+    assert counts[4] == 16
 
 
 def test_prepare_training_data_widens_quantiles(monkeypatch):
@@ -85,7 +87,9 @@ def test_prepare_training_data_drops_on_few_unique(monkeypatch, caplog):
     monkeypatch.setattr(train_real_model, "load_feature_list", lambda: ["feat"])
 
     with caplog.at_level("WARNING", logger=train_real_model.logger.name):
-        X, y = train_real_model.prepare_training_data("SYM", "coin", min_unique_samples=6)
+        X, y = train_real_model.prepare_training_data(
+            "SYM", "coin", min_unique_samples=6, augment_ratio=2.0
+        )
     assert X is None and y is None
     assert any("unique rows" in r.getMessage() for r in caplog.records)
 


### PR DESCRIPTION
## Summary
- allow compute_return_thresholds to enforce minimum spacing between return buckets
- cap oversampling via new augment_ratio parameter and support configurable min_threshold_gap
- expose new tuning flags in CLI and update tests

## Testing
- `pytest tests/test_prepare_training_data.py`
- `pytest` *(fails: requests.exceptions.ProxyError in blockchain chart endpoint tests)*

------
https://chatgpt.com/codex/tasks/task_e_68b60ab3c354832c9919bf2fdc11d27d