### PR TITLE
Expose grid search parallelism and verbosity

### DIFF
--- a/train_real_model.py
+++ b/train_real_model.py
@@ -1059,7 +1059,9 @@ def main():
         help="Number of parameter settings sampled in randomized search",
     )
     parser.add_argument(
+        "--gs-verbose",
         "--verbose",
+        dest="gs_verbose",
         type=int,
         default=1,
         help="Grid search verbosity level",
@@ -1081,7 +1083,7 @@ def main():
     min_volume = 0 if args.ignore_volume else args.min_volume
 
     if sys.platform.startswith("win") and args.n_jobs != 1:
-        logger.warning("n_jobs > 1 is not supported on Windows; using 1")
+        logger.warning("n_jobs != 1 is not supported on Windows; using 1")
     n_jobs = 1 if sys.platform.startswith("win") else args.n_jobs
 
     if args.fast:
@@ -1163,7 +1165,7 @@ def main():
         oversampler=None if args.oversampler == "none" else args.oversampler,
         param_scale=args.param_scale,
         cv_splits=args.cv_splits,
-        verbose=args.verbose,
+        verbose=args.gs_verbose,
         n_jobs=n_jobs,
         class_weight=args.class_weight,
         random_search=args.random_search,


### PR DESCRIPTION
## Summary
- add `--gs-verbose` CLI option (alias for `--verbose`) to control `GridSearchCV` verbosity
- respect `--n-jobs` with Windows-friendly default, allowing `-1` for full core usage on non-Windows

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b61f65a2b0832c850dd9562b7a3f21